### PR TITLE
feat(dashboard): add server-side validation and HTML5 input hints for entity forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,5 @@ prompts
 .playwright-mcp
 *.png
 coverage
+# Ignore the shared rules directory
+.claude/rules/shared/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1357,6 +1358,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ApiDispatcher.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ApiDispatcher.cs
@@ -4,12 +4,9 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.AspNetCore.Http;
-
 using NDjango.Admin.AspNetCore.AdminDashboard.Routing;
 using NDjango.Admin.AspNetCore.AdminDashboard.Services;
-
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -64,10 +61,38 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 return;
             }
 
-            var form = await context.HttpContext.Request.ReadFormAsync(ct);
+            if (!context.HttpContext.Request.HasFormContentType) {
+                var badContentTypeErrors = new List<FieldError> { new FieldError(string.Empty, "Submitted form has an invalid content type. Expected application/x-www-form-urlencoded or multipart/form-data.") };
+                await RenderFormWithErrorsAsync(context, match, metadataService, new JObject(), badContentTypeErrors, isEdit: false, ct);
+                return;
+            }
+
+            IFormCollection form;
+            try {
+                form = await context.HttpContext.Request.ReadFormAsync(ct);
+            }
+            catch (InvalidDataException) {
+                var invalidFormErrors = new List<FieldError> { new FieldError(string.Empty, "Submitted form contains invalid characters (e.g. null bytes).") };
+                await RenderFormWithErrorsAsync(context, match, metadataService, new JObject(), invalidFormErrors, isEdit: false, ct);
+                return;
+            }
             var props = FormToJObject(form, entity);
 
-            var record = await metadataService.CreateRecordAsync(entityId, props, ct);
+            var errors = FieldValidator.Validate(entity, props);
+            if (errors.Count > 0) {
+                await RenderFormWithErrorsAsync(context, match, metadataService, props, errors, isEdit: false, ct);
+                return;
+            }
+
+            object record;
+            try {
+                record = await metadataService.CreateRecordAsync(entityId, props, ct);
+            }
+            catch (DataIntegrityException ex) {
+                var saveErrors = new List<FieldError> { new FieldError(string.Empty, ex.Message) };
+                await RenderFormWithErrorsAsync(context, match, metadataService, props, saveErrors, isEdit: false, ct);
+                return;
+            }
             var saveAction = form["_save_action"].FirstOrDefault() ?? "save";
 
             string newId;
@@ -104,7 +129,22 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             }
 
             var recordId = match.Values["id"];
-            var form = await context.HttpContext.Request.ReadFormAsync(ct);
+
+            if (!context.HttpContext.Request.HasFormContentType) {
+                var badContentTypeErrors = new List<FieldError> { new FieldError(string.Empty, "Submitted form has an invalid content type. Expected application/x-www-form-urlencoded or multipart/form-data.") };
+                await RenderFormWithErrorsAsync(context, match, metadataService, new JObject(), badContentTypeErrors, isEdit: true, ct);
+                return;
+            }
+
+            IFormCollection form;
+            try {
+                form = await context.HttpContext.Request.ReadFormAsync(ct);
+            }
+            catch (InvalidDataException) {
+                var invalidFormErrors = new List<FieldError> { new FieldError(string.Empty, "Submitted form contains invalid characters (e.g. null bytes).") };
+                await RenderFormWithErrorsAsync(context, match, metadataService, new JObject(), invalidFormErrors, isEdit: true, ct);
+                return;
+            }
             var props = FormToJObject(form, entity);
 
             var pkAttrs = entity.GetPrimaryKeyDataAttributes();
@@ -131,7 +171,30 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 }
             }
 
-            await metadataService.UpdateRecordAsync(entityId, props, ct);
+            StripBlankPasswordFields(entity, props);
+
+            var errors = FieldValidator.Validate(entity, props, isEdit: true);
+            if (errors.Count > 0) {
+                await RenderFormWithErrorsAsync(context, match, metadataService, props, errors, isEdit: true, ct);
+                return;
+            }
+
+            try {
+                await metadataService.UpdateRecordAsync(entityId, props, ct);
+            }
+            catch (RecordNotFoundException) {
+                context.HttpContext.Response.StatusCode = 404;
+                return;
+            }
+            catch (InvalidRecordKeyException) {
+                context.HttpContext.Response.StatusCode = 400;
+                return;
+            }
+            catch (DataIntegrityException ex) {
+                var saveErrors = new List<FieldError> { new FieldError(string.Empty, ex.Message) };
+                await RenderFormWithErrorsAsync(context, match, metadataService, props, saveErrors, isEdit: true, ct);
+                return;
+            }
             var saveAction = form["_save_action"].FirstOrDefault() ?? "save";
 
             var redirectUrl = saveAction switch
@@ -182,7 +245,22 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 props[pkAttrs[0].PropName] = JToken.FromObject(ConvertValue(recordId, pkAttrs[0].DataType));
             }
 
-            await metadataService.DeleteRecordAsync(entityId, props, ct);
+            try {
+                await metadataService.DeleteRecordAsync(entityId, props, ct);
+            }
+            catch (RecordNotFoundException) {
+                context.HttpContext.Response.StatusCode = 404;
+                return;
+            }
+            catch (InvalidRecordKeyException) {
+                context.HttpContext.Response.StatusCode = 400;
+                return;
+            }
+            catch (DataIntegrityException ex) {
+                var errorMsg = System.Net.WebUtility.UrlEncode(ex.Message);
+                context.HttpContext.Response.Redirect($"{context.BasePath}/{entityId}/?_msg={errorMsg}&_msg_level=error");
+                return;
+            }
             context.HttpContext.Response.Redirect($"{context.BasePath}/{entityId}/");
         }
 
@@ -195,6 +273,27 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             context.HttpContext.Response.ContentType = "application/json";
             var json = JsonConvert.SerializeObject(dataset);
             await context.HttpContext.Response.WriteAsync(json, ct);
+        }
+
+        private static void StripBlankPasswordFields(MetaEntity entity, JObject props)
+        {
+            foreach (var attr in entity.Attributes) {
+                if (attr.InputType != InputTypeHint.Password)
+                    continue;
+                if (string.IsNullOrEmpty(attr.PropName))
+                    continue;
+                if (!props.TryGetValue(attr.PropName, out var token))
+                    continue;
+
+                var str = token?.Type == JTokenType.String ? token.Value<string>() : token?.ToString();
+                // IsNullOrEmpty (not IsNullOrWhiteSpace): a whitespace-only password is a deliberate
+                // (if weak) value the user submitted. Stripping it on edit would silently keep the
+                // old hash while the user thinks they set a new password; accepting it on create
+                // would persist the whitespace. Treat whitespace as "a value" and let downstream
+                // validation decide whether to reject it.
+                if (string.IsNullOrEmpty(str))
+                    props.Remove(attr.PropName);
+            }
         }
 
         private static JObject FormToJObject(IFormCollection form, MetaEntity entity)
@@ -231,6 +330,21 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 }
             }
             return props;
+        }
+
+        private static async Task RenderFormWithErrorsAsync(AdminDashboardContext context, DashboardRouteMatch match,
+            AdminMetadataService metadataService, JObject props, List<FieldError> errors, bool isEdit, CancellationToken ct)
+        {
+            var groupingService = new EntityGroupingService(metadataService, context.Options);
+            var errorDict = errors.ToDictionary(e => e.PropName, e => e.Message);
+            var submittedValues = new Dictionary<string, object>();
+            foreach (var p in props.Properties()) {
+                submittedValues[p.Name] = p.Value.Type == JTokenType.Null ? null : p.Value.ToObject<object>();
+            }
+
+            var viewDispatcher = new RazorViewDispatcher(isEdit ? "Entity/Edit" : "Entity/Create");
+            await viewDispatcher.RenderEntityFormWithErrorsAsync(context, match, metadataService, groupingService,
+                isEdit, submittedValues, errorDict, ct);
         }
 
         internal static object ConvertValue(string value, DataType dataType, Type clrType = null)
@@ -272,6 +386,11 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             var entity = await metadataService.GetEntityAsync(entityId, ct);
             if (entity == null) {
                 context.HttpContext.Response.StatusCode = 404;
+                return;
+            }
+
+            if (!context.HttpContext.Request.HasFormContentType) {
+                context.HttpContext.Response.StatusCode = 400;
                 return;
             }
 
@@ -330,6 +449,11 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             var entity = await metadataService.GetEntityAsync(entityId, ct);
             if (entity == null) {
                 context.HttpContext.Response.StatusCode = 404;
+                return;
+            }
+
+            if (!context.HttpContext.Request.HasFormContentType) {
+                context.HttpContext.Response.StatusCode = 400;
                 return;
             }
 

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ApiDispatcher.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ApiDispatcher.cs
@@ -354,14 +354,20 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
 
             var underlyingType = clrType != null ? Nullable.GetUnderlyingType(clrType) ?? clrType : null;
 
+            // Parse all date/time types under InvariantCulture so binder and FieldValidator
+            // interpret ambiguous inputs (e.g. "12/03/2025") identically regardless of the
+            // host thread's current culture. Must stay aligned with FieldValidator.ValidateParse.
             if (underlyingType == typeof(DateOnly))
-                return DateOnly.TryParse(value, out var d) ? d : (object)value;
+                return DateOnly.TryParse(value, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.None, out var d) ? d : (object)value;
 
             if (underlyingType == typeof(TimeOnly))
-                return TimeOnly.TryParse(value, out var t) ? t : (object)value;
+                return TimeOnly.TryParse(value, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.None, out var t) ? t : (object)value;
 
             if (underlyingType == typeof(DateTimeOffset))
-                return DateTimeOffset.TryParse(value, out var dto) ? dto : (object)value;
+                return DateTimeOffset.TryParse(value, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeLocal, out var dto) ? dto : (object)value;
 
             return dataType switch
             {
@@ -372,8 +378,11 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 DataType.Currency => decimal.TryParse(value, System.Globalization.NumberStyles.Any,
                     System.Globalization.CultureInfo.InvariantCulture, out var m) ? m : (object)value,
                 DataType.Bool => value == "on" || value == "true" || value == "True",
-                DataType.Date or DataType.DateTime => DateTime.TryParse(value, out var dt) ? dt : (object)value,
-                DataType.Time => TimeSpan.TryParse(value, out var ts) ? ts : (object)value,
+                DataType.Date or DataType.DateTime => DateTime.TryParse(value,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeLocal, out var dt) ? dt : (object)value,
+                DataType.Time => TimeSpan.TryParse(value,
+                    System.Globalization.CultureInfo.InvariantCulture, out var ts) ? ts : (object)value,
                 DataType.Guid => Guid.TryParse(value, out var g) ? g : (object)value,
                 _ => value,
             };

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ApiDispatcher.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ApiDispatcher.cs
@@ -337,7 +337,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
         {
             var groupingService = new EntityGroupingService(metadataService, context.Options);
             var errorDict = errors.ToDictionary(e => e.PropName, e => e.Message);
-            var submittedValues = new Dictionary<string, object>();
+            var submittedValues = new Dictionary<string, object?>();
             foreach (var p in props.Properties()) {
                 submittedValues[p.Name] = p.Value.Type == JTokenType.Null ? null : p.Value.ToObject<object>();
             }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/RazorViewDispatcher.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/RazorViewDispatcher.cs
@@ -86,7 +86,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             }
 
             var query = context.HttpContext.Request.Query;
-            var page = int.TryParse(query["page"], out var p) ? p : 1;
+            var page = int.TryParse(query["page"], out var p) ? Math.Max(1, p) : 1;
             var pageSize = context.Options.DefaultRecordsPerPage;
             var searchQuery = query["q"].FirstOrDefault();
             var sortField = query["sort"].FirstOrDefault();
@@ -107,7 +107,10 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             }
 
             var sorters = new List<NDjango.Admin.Services.EasySorter>();
-            if (!string.IsNullOrEmpty(sortField)) {
+            var isSortFieldValid = !string.IsNullOrEmpty(sortField)
+                && entity.Attributes.Any(a => a.Kind != EntityAttrKind.Lookup
+                    && string.Equals(a.PropName, sortField, StringComparison.Ordinal));
+            if (isSortFieldValid) {
                 sorters.Add(new NDjango.Admin.Services.EasySorter
                 {
                     FieldName = sortField,
@@ -116,11 +119,13 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 });
             }
             else {
+                sortField = null;
                 var defaultSorters = await metadataService.GetDefaultSortersAsync(entityId, ct);
                 sorters.AddRange(defaultSorters);
             }
 
-            var offset = (page - 1) * pageSize;
+            var offsetLong = ((long)page - 1) * pageSize;
+            var offset = offsetLong > int.MaxValue ? int.MaxValue : (int)offsetLong;
             // COUNT and data fetch run sequentially because both share the same DbContext,
             // which is not thread-safe. Do not parallelize with Task.WhenAll.
             var totalRecords = await metadataService.GetTotalRecordsAsync(entityId, filters, false, ct);
@@ -217,8 +222,27 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             await ViewRenderer.RenderEntityListViewAsync(context.HttpContext, viewModel, context.AuthenticatedUsername);
         }
 
-        private async Task RenderEntityFormAsync(AdminDashboardContext context, DashboardRouteMatch match,
+        private Task RenderEntityFormAsync(AdminDashboardContext context, DashboardRouteMatch match,
             AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit, CancellationToken ct)
+        {
+            return RenderEntityFormAsync(context, match, metadataService, groupingService, isEdit,
+                submittedValues: null, errors: null, ct);
+        }
+
+        internal async Task RenderEntityFormWithErrorsAsync(AdminDashboardContext context, DashboardRouteMatch match,
+            AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit,
+            IReadOnlyDictionary<string, object> submittedValues, IReadOnlyDictionary<string, string> errors,
+            CancellationToken ct)
+        {
+            context.HttpContext.Response.StatusCode = 400;
+            await RenderEntityFormAsync(context, match, metadataService, groupingService, isEdit,
+                submittedValues, errors, ct);
+        }
+
+        private async Task RenderEntityFormAsync(AdminDashboardContext context, DashboardRouteMatch match,
+            AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit,
+            IReadOnlyDictionary<string, object> submittedValues, IReadOnlyDictionary<string, string> errors,
+            CancellationToken ct)
         {
             var entityId = match.Values["entityId"];
             var entity = await metadataService.GetEntityAsync(entityId, ct);
@@ -251,7 +275,21 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 else {
                     keys = new Dictionary<string, string> { { pkAttrs[0].PropName, recordId } };
                 }
-                record = await metadataService.FetchRecordAsync(entityId, keys, ct);
+                try {
+                    record = await metadataService.FetchRecordAsync(entityId, keys, ct);
+                }
+                catch (RecordNotFoundException) {
+                    context.HttpContext.Response.StatusCode = 404;
+                    return;
+                }
+                catch (InvalidRecordKeyException) {
+                    context.HttpContext.Response.StatusCode = 404;
+                    return;
+                }
+                if (record == null) {
+                    context.HttpContext.Response.StatusCode = 404;
+                    return;
+                }
             }
 
             var fields = new List<FieldViewModel>();
@@ -280,7 +318,10 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                         field.IsEditable = false;
                     }
 
-                    if (record != null && attr.DataAttr?.PropInfo != null) {
+                    if (submittedValues != null && submittedValues.TryGetValue(field.PropName, out var submittedLookup)) {
+                        field.Value = submittedLookup;
+                    }
+                    else if (record != null && attr.DataAttr?.PropInfo != null) {
                         field.Value = attr.DataAttr.PropInfo.GetValue(record);
                     }
 
@@ -291,6 +332,12 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                     if (!showOnForm)
                         continue;
 
+                    // Password inputs on edit forms render with an empty value by design
+                    // (leave blank to preserve the existing hash). Emitting `required` would
+                    // make the browser block submission until the user retypes a password.
+                    var isRequired = !attr.IsNullable
+                        && !(isEdit && attr.InputType == InputTypeHint.Password);
+
                     var field = new FieldViewModel
                     {
                         Id = attr.Id,
@@ -299,13 +346,27 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                         DataType = attr.DataType,
                         Kind = attr.Kind,
                         IsPrimaryKey = attr.IsPrimaryKey,
-                        IsRequired = !attr.IsNullable,
+                        IsRequired = isRequired,
                         IsEditable = attr.IsEditable,
                         DisplayFormat = attr.DisplayFormat,
                         ClrType = attr.PropInfo?.PropertyType,
+                        MaxLength = attr.MaxLength,
+                        MinLength = attr.MinLength,
+                        MinValue = attr.MinValue,
+                        MaxValue = attr.MaxValue,
+                        MinDateTime = attr.MinDateTime,
+                        MaxDateTime = attr.MaxDateTime,
+                        RegexPattern = attr.RegexPattern,
+                        RegexErrorMessage = attr.RegexErrorMessage,
+                        Precision = attr.Precision,
+                        Scale = attr.Scale,
+                        InputType = attr.InputType,
                     };
 
-                    if (record != null && attr.PropInfo != null) {
+                    if (submittedValues != null && submittedValues.TryGetValue(attr.PropName, out var submitted)) {
+                        field.Value = submitted;
+                    }
+                    else if (record != null && attr.PropInfo != null) {
                         field.Value = attr.PropInfo.GetValue(record);
                     }
                     else if (attr.DefaultValue != null) {
@@ -328,7 +389,13 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 IsEdit = isEdit,
                 IsReadOnly = context.Options.IsReadOnly || !entity.IsEditable,
                 Fields = fields,
-                SidebarGroups = sidebarGroups
+                SidebarGroups = sidebarGroups,
+                Errors = errors != null
+                    ? new Dictionary<string, string>(errors)
+                    : new Dictionary<string, string>(),
+                SubmittedValues = submittedValues != null
+                    ? new Dictionary<string, object>(submittedValues)
+                    : new Dictionary<string, object>()
             };
 
             await ViewRenderer.RenderEntityFormViewAsync(context.HttpContext, viewModel, context.AuthenticatedUsername);
@@ -365,7 +432,18 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             else {
                 keys = new Dictionary<string, string> { { pkAttrs[0].PropName, recordId } };
             }
-            var record = await metadataService.FetchRecordAsync(entityId, keys, ct);
+            object record;
+            try {
+                record = await metadataService.FetchRecordAsync(entityId, keys, ct);
+            }
+            catch (RecordNotFoundException) {
+                context.HttpContext.Response.StatusCode = 404;
+                return;
+            }
+            catch (InvalidRecordKeyException) {
+                context.HttpContext.Response.StatusCode = 404;
+                return;
+            }
             if (record == null) {
                 context.HttpContext.Response.StatusCode = 404;
                 return;

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/RazorViewDispatcher.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/RazorViewDispatcher.cs
@@ -231,7 +231,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
 
         internal async Task RenderEntityFormWithErrorsAsync(AdminDashboardContext context, DashboardRouteMatch match,
             AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit,
-            IReadOnlyDictionary<string, object> submittedValues, IReadOnlyDictionary<string, string> errors,
+            IReadOnlyDictionary<string, object>? submittedValues, IReadOnlyDictionary<string, string>? errors,
             CancellationToken ct)
         {
             context.HttpContext.Response.StatusCode = 400;
@@ -241,7 +241,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
 
         private async Task RenderEntityFormAsync(AdminDashboardContext context, DashboardRouteMatch match,
             AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit,
-            IReadOnlyDictionary<string, object> submittedValues, IReadOnlyDictionary<string, string> errors,
+            IReadOnlyDictionary<string, object>? submittedValues, IReadOnlyDictionary<string, string>? errors,
             CancellationToken ct)
         {
             var entityId = match.Values["entityId"];

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/RazorViewDispatcher.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/RazorViewDispatcher.cs
@@ -107,10 +107,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             }
 
             var sorters = new List<NDjango.Admin.Services.EasySorter>();
-            var isSortFieldValid = !string.IsNullOrEmpty(sortField)
+            if (!string.IsNullOrEmpty(sortField)
                 && entity.Attributes.Any(a => a.Kind != EntityAttrKind.Lookup
-                    && string.Equals(a.PropName, sortField, StringComparison.Ordinal));
-            if (isSortFieldValid) {
+                    && string.Equals(a.PropName, sortField, StringComparison.Ordinal))) {
                 sorters.Add(new NDjango.Admin.Services.EasySorter
                 {
                     FieldName = sortField,
@@ -231,7 +230,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
 
         internal async Task RenderEntityFormWithErrorsAsync(AdminDashboardContext context, DashboardRouteMatch match,
             AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit,
-            IReadOnlyDictionary<string, object>? submittedValues, IReadOnlyDictionary<string, string>? errors,
+            IReadOnlyDictionary<string, object?>? submittedValues, IReadOnlyDictionary<string, string>? errors,
             CancellationToken ct)
         {
             context.HttpContext.Response.StatusCode = 400;
@@ -241,7 +240,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
 
         private async Task RenderEntityFormAsync(AdminDashboardContext context, DashboardRouteMatch match,
             AdminMetadataService metadataService, EntityGroupingService groupingService, bool isEdit,
-            IReadOnlyDictionary<string, object>? submittedValues, IReadOnlyDictionary<string, string>? errors,
+            IReadOnlyDictionary<string, object?>? submittedValues, IReadOnlyDictionary<string, string>? errors,
             CancellationToken ct)
         {
             var entityId = match.Values["entityId"];
@@ -394,8 +393,8 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                     ? new Dictionary<string, string>(errors)
                     : new Dictionary<string, string>(),
                 SubmittedValues = submittedValues != null
-                    ? new Dictionary<string, object>(submittedValues)
-                    : new Dictionary<string, object>()
+                    ? new Dictionary<string, object?>(submittedValues)
+                    : new Dictionary<string, object?>()
             };
 
             await ViewRenderer.RenderEntityFormViewAsync(context.HttpContext, viewModel, context.AuthenticatedUsername);

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
@@ -283,14 +283,28 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 : $"{model.BasePath}/{model.EntityId}/add/";
 
             content.Append($"<form method=\"post\" action=\"{formAction}\" class=\"entity-form\">");
+
+            if (model.Errors != null && model.Errors.TryGetValue(string.Empty, out var nonFieldError)
+                && !string.IsNullOrEmpty(nonFieldError)) {
+                content.Append($"<ul class=\"errorlist nonfield\"><li>{Encode(nonFieldError)}</li></ul>");
+            }
+
             content.Append("<fieldset class=\"module aligned\">");
 
             foreach (var field in model.Fields) {
-                content.Append("<div class=\"form-row\">");
+                var hasError = model.Errors != null
+                    && model.Errors.TryGetValue(field.PropName, out var fieldError);
+                var errorMessage = hasError ? model.Errors[field.PropName] : null;
+                var rowClass = hasError ? "form-row errors" : "form-row";
+                content.Append($"<div class=\"{rowClass}\">");
                 content.Append($"<label for=\"id_{field.PropName}\">{Encode(field.Caption)}:");
                 if (field.IsEditable && field.IsRequired)
                     content.Append(" <span class=\"required\">*</span>");
                 content.Append("</label>");
+
+                if (hasError) {
+                    content.Append($"<ul class=\"errorlist\"><li>{Encode(errorMessage)}</li></ul>");
+                }
 
                 if (!field.IsEditable) {
                     var displayValue = field.Value?.ToString() ?? "-";
@@ -423,6 +437,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             var id = $"id_{field.PropName}";
             var required = field.IsRequired ? " required" : "";
             var readOnly = !field.IsEditable ? " readonly" : "";
+            var validation = BuildValidationAttrs(field);
 
             switch (field.DataType) {
                 case DataType.Bool:
@@ -430,38 +445,151 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                     content.Append($"<input type=\"checkbox\" id=\"{id}\" name=\"{field.PropName}\"{isChecked}{readOnly} />");
                     break;
                 case DataType.Date:
-                    content.Append($"<input type=\"date\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly} />");
+                    content.Append($"<input type=\"date\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly}{validation} />");
                     break;
                 case DataType.DateTime:
                     if (IsDateTimeOffset(field)) {
-                        content.Append($"<input type=\"text\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly} />");
+                        content.Append($"<input type=\"text\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly}{validation} />");
                     }
                     else {
-                        content.Append($"<input type=\"datetime-local\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly} />");
+                        content.Append($"<input type=\"datetime-local\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly}{validation} />");
                     }
                     break;
                 case DataType.Int32:
                 case DataType.Int64:
                 case DataType.Word:
                 case DataType.Byte:
-                    content.Append($"<input type=\"number\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly} />");
+                    content.Append($"<input type=\"number\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly}{validation} />");
                     break;
                 case DataType.Float:
                 case DataType.Currency:
-                    content.Append($"<input type=\"number\" step=\"any\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly} />");
+                    var stepAttr = field.Scale.HasValue && field.Scale.Value >= 0
+                        ? $" step=\"{BuildStepFromScale(field.Scale.Value)}\""
+                        : " step=\"any\"";
+                    content.Append($"<input type=\"number\"{stepAttr} id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly}{validation} />");
                     break;
                 case DataType.Memo:
-                    content.Append($"<textarea id=\"{id}\" name=\"{field.PropName}\" rows=\"5\"{required}{readOnly}>{Encode(value)}</textarea>");
+                    content.Append($"<textarea id=\"{id}\" name=\"{field.PropName}\" rows=\"5\"{required}{readOnly}{validation}>{Encode(value)}</textarea>");
                     break;
                 default:
                     if (field.IsPrimaryKey && !field.IsEditable) {
                         content.Append($"<span class=\"readonly-value\">{Encode(value)}</span>");
                     }
+                    else if (field.InputType == InputTypeHint.Password) {
+                        content.Append($"<input type=\"password\" id=\"{id}\" name=\"{field.PropName}\" value=\"\" autocomplete=\"new-password\"{required}{readOnly}{validation} />");
+                    }
                     else {
-                        content.Append($"<input type=\"text\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly} />");
+                        var inputType = field.InputType switch
+                        {
+                            InputTypeHint.Email => "email",
+                            InputTypeHint.Url => "url",
+                            InputTypeHint.Tel => "tel",
+                            _ => "text"
+                        };
+                        content.Append($"<input type=\"{inputType}\" id=\"{id}\" name=\"{field.PropName}\" value=\"{Encode(value)}\"{required}{readOnly}{validation} />");
                     }
                     break;
             }
+        }
+
+        /// <summary>
+        /// Builds the HTML5 validation attribute fragment (maxlength/minlength/min/max/pattern/title)
+        /// for a field. Returns an empty string when no validation metadata applies.
+        /// Fragment is leading-space-prefixed so it can be safely appended to an input tag.
+        /// </summary>
+        internal static string BuildValidationAttrs(FieldViewModel field)
+        {
+            if (field == null)
+                return "";
+            var sb = new StringBuilder();
+
+            var isStringLike = field.DataType == DataType.String
+                || field.DataType == DataType.Memo
+                || field.DataType == DataType.FixedChar;
+
+            var isNumeric = field.DataType == DataType.Int32
+                || field.DataType == DataType.Int64
+                || field.DataType == DataType.Word
+                || field.DataType == DataType.Byte
+                || field.DataType == DataType.Float
+                || field.DataType == DataType.Currency;
+
+            if (isStringLike) {
+                if (field.MaxLength.HasValue && field.MaxLength.Value > 0) {
+                    sb.Append($" maxlength=\"{field.MaxLength.Value}\"");
+                }
+                if (field.MinLength.HasValue && field.MinLength.Value > 0) {
+                    sb.Append($" minlength=\"{field.MinLength.Value}\"");
+                }
+                if (!string.IsNullOrEmpty(field.RegexPattern) && IsHtml5SafeRegex(field.RegexPattern)) {
+                    sb.Append($" pattern=\"{Encode(StripRegexAnchors(field.RegexPattern))}\"");
+                    var title = !string.IsNullOrEmpty(field.RegexErrorMessage)
+                        ? field.RegexErrorMessage
+                        : "Please match the requested format.";
+                    sb.Append($" title=\"{Encode(title)}\"");
+                }
+            }
+
+            if (isNumeric) {
+                if (field.MinValue.HasValue) {
+                    sb.Append($" min=\"{field.MinValue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}\"");
+                }
+                if (field.MaxValue.HasValue) {
+                    sb.Append($" max=\"{field.MaxValue.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}\"");
+                }
+            }
+
+            if (field.DataType == DataType.Date) {
+                if (field.MinDateTime.HasValue) {
+                    sb.Append($" min=\"{field.MinDateTime.Value.ToString("yyyy-MM-dd")}\"");
+                }
+                if (field.MaxDateTime.HasValue) {
+                    sb.Append($" max=\"{field.MaxDateTime.Value.ToString("yyyy-MM-dd")}\"");
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true when a regex pattern is safe to emit as HTML5 pattern= attribute.
+        /// HTML5 uses the JS regex engine (ECMA-262) and implicitly anchors the pattern with ^$.
+        /// Reject patterns using inline flags (e.g. `(?i)`, `(?-i)`) or embedded newlines, which
+        /// either parse differently or make no sense in the HTML5 context.
+        /// </summary>
+        internal static bool IsHtml5SafeRegex(string pattern)
+        {
+            if (string.IsNullOrEmpty(pattern))
+                return false;
+            if (pattern.IndexOf("(?") >= 0)
+                return false;
+            if (pattern.IndexOfAny(new[] { '\n', '\r' }) >= 0)
+                return false;
+            return true;
+        }
+
+        private static string StripRegexAnchors(string pattern)
+        {
+            if (string.IsNullOrEmpty(pattern))
+                return pattern;
+            var stripped = pattern;
+            if (stripped.StartsWith("^"))
+                stripped = stripped.Substring(1);
+            if (stripped.EndsWith("$") && !stripped.EndsWith("\\$")) {
+                stripped = stripped.Substring(0, stripped.Length - 1);
+            }
+            return stripped;
+        }
+
+        private static string BuildStepFromScale(int scale)
+        {
+            if (scale <= 0)
+                return "1";
+            var sb = new StringBuilder("0.");
+            for (var i = 1; i < scale; i++)
+                sb.Append('0');
+            sb.Append('1');
+            return sb.ToString();
         }
 
         private static void RenderSelectField(StringBuilder content, FieldViewModel field, string basePath)
@@ -487,7 +615,6 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             string authenticatedUsername = null)
         {
             httpContext.Response.ContentType = "text/html; charset=utf-8";
-            httpContext.Response.StatusCode = 200;
 
             var sb = new StringBuilder();
             sb.Append("<!DOCTYPE html><html lang=\"en\"><head>");

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
@@ -573,9 +573,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             if (string.IsNullOrEmpty(pattern))
                 return pattern;
             var stripped = pattern;
-            if (stripped.StartsWith("^"))
+            if (stripped.StartsWith('^'))
                 stripped = stripped.Substring(1);
-            if (stripped.EndsWith("$") && !stripped.EndsWith("\\$")) {
+            if (stripped.EndsWith('$') && !stripped.EndsWith("\\$")) {
                 stripped = stripped.Substring(0, stripped.Length - 1);
             }
             return stripped;

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
@@ -292,9 +292,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
             content.Append("<fieldset class=\"module aligned\">");
 
             foreach (var field in model.Fields) {
+                string? fieldError = null;
                 var hasError = model.Errors != null
-                    && model.Errors.TryGetValue(field.PropName, out var fieldError);
-                var errorMessage = hasError ? model.Errors[field.PropName] : null;
+                    && model.Errors.TryGetValue(field.PropName, out fieldError);
                 var rowClass = hasError ? "form-row errors" : "form-row";
                 content.Append($"<div class=\"{rowClass}\">");
                 content.Append($"<label for=\"id_{field.PropName}\">{Encode(field.Caption)}:");
@@ -303,7 +303,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 content.Append("</label>");
 
                 if (hasError) {
-                    content.Append($"<ul class=\"errorlist\"><li>{Encode(errorMessage)}</li></ul>");
+                    content.Append($"<ul class=\"errorlist\"><li>{Encode(fieldError)}</li></ul>");
                 }
 
                 if (!field.IsEditable) {

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Dispatchers/ViewRenderer.cs
@@ -303,7 +303,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Dispatchers
                 content.Append("</label>");
 
                 if (hasError) {
-                    content.Append($"<ul class=\"errorlist\"><li>{Encode(fieldError)}</li></ul>");
+                    content.Append($"<ul class=\"errorlist\"><li>{Encode(fieldError!)}</li></ul>");
                 }
 
                 if (!field.IsEditable) {

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+using Newtonsoft.Json.Linq;
+
+namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
+{
+    /// <summary>
+    /// Represents a single server-side validation error.
+    /// </summary>
+    public sealed record FieldError(string PropName, string Message);
+
+    /// <summary>
+    /// Server-side validation runner. Mirrors the HTML5 attributes emitted by <c>ViewRenderer</c>
+    /// but is authoritative: runs regardless of whether the browser enforced anything, and catches
+    /// patterns that <c>IsHtml5SafeRegex</c> refused to emit (e.g. inline flags).
+    /// </summary>
+    public static class FieldValidator
+    {
+        /// <summary>
+        /// Validates the submitted property bag against an entity's metadata.
+        /// </summary>
+        /// <param name="entity">The entity whose attributes define the constraints.</param>
+        /// <param name="props">Submitted values keyed by prop name (as produced by <c>FormToJObject</c>).</param>
+        /// <returns>
+        /// A list of errors, one per failing attribute. Empty when validation passes.
+        /// Errors stop at the first failing rule per field.
+        /// </returns>
+        public static List<FieldError> Validate(MetaEntity entity, JObject props, bool isEdit = false)
+        {
+            var errors = new List<FieldError>();
+            if (entity == null)
+                return errors;
+
+            foreach (var attr in entity.Attributes) {
+                if (attr.Kind == EntityAttrKind.Lookup)
+                    continue;
+                if (!attr.IsEditable)
+                    continue;
+                var shownOnForm = isEdit ? attr.ShowOnEdit : attr.ShowOnCreate;
+                if (!shownOnForm)
+                    continue;
+
+                var propName = attr.PropName;
+                if (string.IsNullOrEmpty(propName))
+                    continue;
+
+                var hasValue = props != null
+                    && props.TryGetValue(propName, out var token)
+                    && token != null
+                    && token.Type != JTokenType.Null;
+
+                if (!hasValue) {
+                    if (isEdit && attr.InputType == InputTypeHint.Password)
+                        continue;
+                    if (!attr.IsNullable && attr.DataType != DataType.Bool) {
+                        errors.Add(new FieldError(propName, "This field is required."));
+                    }
+                    continue;
+                }
+
+                var raw = props[propName];
+                var stringValue = raw.Type == JTokenType.String
+                    ? raw.Value<string>()
+                    : raw.ToString();
+
+                if (!attr.IsNullable && string.IsNullOrEmpty(stringValue) && attr.DataType != DataType.Bool) {
+                    errors.Add(new FieldError(propName, "This field is required."));
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(stringValue))
+                    continue;
+
+                var error = ValidateAttribute(attr, stringValue);
+                if (error != null) {
+                    errors.Add(new FieldError(propName, error));
+                }
+            }
+
+            return errors;
+        }
+
+        private static string ValidateAttribute(MetaEntityAttr attr, string value)
+        {
+            var nullByteError = ValidateNoNullBytes(attr, value);
+            if (nullByteError != null)
+                return nullByteError;
+
+            var lengthError = ValidateLength(attr, value);
+            if (lengthError != null)
+                return lengthError;
+
+            var parseError = ValidateParse(attr, value);
+            if (parseError != null)
+                return parseError;
+
+            var precisionError = ValidatePrecision(attr, value);
+            if (precisionError != null)
+                return precisionError;
+
+            var rangeError = ValidateRange(attr, value);
+            if (rangeError != null)
+                return rangeError;
+
+            var dateError = ValidateDateRange(attr, value);
+            if (dateError != null)
+                return dateError;
+
+            var regexError = ValidateRegex(attr, value);
+            if (regexError != null)
+                return regexError;
+
+            var typedError = ValidateInputType(attr, value);
+            if (typedError != null)
+                return typedError;
+
+            return null;
+        }
+
+        private static string ValidateParse(MetaEntityAttr attr, string value)
+        {
+            switch (attr.DataType) {
+                case DataType.Int32:
+                    if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid integer number.";
+                    break;
+                case DataType.Int64:
+                    if (!long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid integer number.";
+                    break;
+                case DataType.Byte:
+                    if (!byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid integer number between 0 and 255.";
+                    break;
+                case DataType.Word:
+                    if (!short.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid integer number.";
+                    break;
+                case DataType.Float:
+                    if (!double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid number.";
+                    break;
+                case DataType.Currency:
+                    if (!decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid number.";
+                    break;
+                case DataType.Guid:
+                    if (!Guid.TryParse(value, out _))
+                        return "Enter a valid UUID value.";
+                    break;
+                case DataType.Date:
+                case DataType.DateTime:
+                    if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out _))
+                        return "Enter a valid date.";
+                    break;
+                case DataType.Time:
+                    if (!TimeSpan.TryParse(value, CultureInfo.InvariantCulture, out _))
+                        return "Enter a valid time.";
+                    break;
+            }
+            return null;
+        }
+
+        private static string ValidatePrecision(MetaEntityAttr attr, string value)
+        {
+            if (attr.DataType != DataType.Currency && attr.DataType != DataType.Float)
+                return null;
+            if (!attr.Precision.HasValue || attr.Precision.Value <= 0)
+                return null;
+
+            if (!decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var numeric))
+                return null;
+
+            var scale = attr.Scale.GetValueOrDefault(0);
+            var maxIntegerDigits = attr.Precision.Value - scale;
+            if (maxIntegerDigits <= 0)
+                return null;
+
+            var integerPart = decimal.Truncate(Math.Abs(numeric));
+            var digits = integerPart == 0 ? 1 : (int)Math.Floor(Math.Log10((double)integerPart) + 1);
+            if (digits > maxIntegerDigits) {
+                return $"Ensure that there are no more than {maxIntegerDigits} digits before the decimal point.";
+            }
+
+            return null;
+        }
+
+        private static string ValidateNoNullBytes(MetaEntityAttr attr, string value)
+        {
+            if (attr.DataType != DataType.String
+                && attr.DataType != DataType.Memo
+                && attr.DataType != DataType.FixedChar)
+                return null;
+
+            if (value.IndexOf('\0') >= 0)
+                return "Null characters are not allowed.";
+
+            return null;
+        }
+
+        private static string ValidateLength(MetaEntityAttr attr, string value)
+        {
+            if (attr.MaxLength.HasValue && value.Length > attr.MaxLength.Value) {
+                return $"Ensure this value has at most {attr.MaxLength.Value} characters (it has {value.Length}).";
+            }
+
+            if (attr.MinLength.HasValue && value.Length < attr.MinLength.Value) {
+                return $"Ensure this value has at least {attr.MinLength.Value} characters (it has {value.Length}).";
+            }
+
+            return null;
+        }
+
+        private static string ValidateRange(MetaEntityAttr attr, string value)
+        {
+            if (!attr.MinValue.HasValue && !attr.MaxValue.HasValue)
+                return null;
+            if (!IsNumericDataType(attr.DataType))
+                return null;
+
+            if (!decimal.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var numeric)) {
+                return "Enter a valid number.";
+            }
+
+            if (attr.MinValue.HasValue && numeric < attr.MinValue.Value) {
+                return $"Ensure this value is greater than or equal to {attr.MinValue.Value.ToString(CultureInfo.InvariantCulture)}.";
+            }
+
+            if (attr.MaxValue.HasValue && numeric > attr.MaxValue.Value) {
+                return $"Ensure this value is less than or equal to {attr.MaxValue.Value.ToString(CultureInfo.InvariantCulture)}.";
+            }
+
+            return null;
+        }
+
+        private static string ValidateDateRange(MetaEntityAttr attr, string value)
+        {
+            if (!attr.MinDateTime.HasValue && !attr.MaxDateTime.HasValue)
+                return null;
+
+            if (!DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out var dt)) {
+                return "Enter a valid date.";
+            }
+
+            if (attr.MinDateTime.HasValue && dt < attr.MinDateTime.Value) {
+                return $"Ensure this date is on or after {attr.MinDateTime.Value:yyyy-MM-dd}.";
+            }
+
+            if (attr.MaxDateTime.HasValue && dt > attr.MaxDateTime.Value) {
+                return $"Ensure this date is on or before {attr.MaxDateTime.Value:yyyy-MM-dd}.";
+            }
+
+            return null;
+        }
+
+        private static string ValidateRegex(MetaEntityAttr attr, string value)
+        {
+            if (string.IsNullOrEmpty(attr.RegexPattern))
+                return null;
+
+            try {
+                if (!Regex.IsMatch(value, attr.RegexPattern, RegexOptions.None, TimeSpan.FromMilliseconds(250))) {
+                    return !string.IsNullOrEmpty(attr.RegexErrorMessage)
+                        ? attr.RegexErrorMessage
+                        : "Enter a valid value.";
+                }
+            }
+            catch (RegexMatchTimeoutException) {
+                return "Enter a valid value.";
+            }
+            catch (ArgumentException) {
+                return "Enter a valid value.";
+            }
+
+            return null;
+        }
+
+        private static string ValidateInputType(MetaEntityAttr attr, string value)
+        {
+            switch (attr.InputType) {
+                case InputTypeHint.Email:
+                    if (!new EmailAddressAttribute().IsValid(value))
+                        return "Enter a valid email address.";
+                    break;
+                case InputTypeHint.Url:
+                    if (!new UrlAttribute().IsValid(value))
+                        return "Enter a valid URL.";
+                    break;
+                case InputTypeHint.Tel:
+                    // Tel is format-free on HTML5 — don't enforce a pattern server-side either.
+                    break;
+            }
+            return null;
+        }
+
+        private static bool IsNumericDataType(DataType dataType)
+        {
+            return dataType == DataType.Int32
+                || dataType == DataType.Int64
+                || dataType == DataType.Word
+                || dataType == DataType.Byte
+                || dataType == DataType.Float
+                || dataType == DataType.Currency;
+        }
+    }
+}

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
@@ -48,8 +48,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
                 if (string.IsNullOrEmpty(propName))
                     continue;
 
+                JToken? token = null;
                 var hasValue = props != null
-                    && props.TryGetValue(propName, out var token)
+                    && props.TryGetValue(propName, out token)
                     && token != null
                     && token.Type != JTokenType.Null;
 
@@ -62,10 +63,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
                     continue;
                 }
 
-                var raw = props[propName];
-                var stringValue = raw.Type == JTokenType.String
-                    ? raw.Value<string>()
-                    : raw.ToString();
+                var stringValue = token!.Type == JTokenType.String
+                    ? token.Value<string>()
+                    : token.ToString();
 
                 if (!attr.IsNullable && string.IsNullOrEmpty(stringValue) && attr.DataType != DataType.Bool) {
                     errors.Add(new FieldError(propName, "This field is required."));
@@ -84,7 +84,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return errors;
         }
 
-        private static string ValidateAttribute(MetaEntityAttr attr, string value)
+        private static string? ValidateAttribute(MetaEntityAttr attr, string value)
         {
             var nullByteError = ValidateNoNullBytes(attr, value);
             if (nullByteError != null)
@@ -121,7 +121,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateParse(MetaEntityAttr attr, string value)
+        private static string? ValidateParse(MetaEntityAttr attr, string value)
         {
             switch (attr.DataType) {
                 case DataType.Int32:
@@ -165,7 +165,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidatePrecision(MetaEntityAttr attr, string value)
+        private static string? ValidatePrecision(MetaEntityAttr attr, string value)
         {
             if (attr.DataType != DataType.Currency && attr.DataType != DataType.Float)
                 return null;
@@ -189,7 +189,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateNoNullBytes(MetaEntityAttr attr, string value)
+        private static string? ValidateNoNullBytes(MetaEntityAttr attr, string value)
         {
             if (attr.DataType != DataType.String
                 && attr.DataType != DataType.Memo
@@ -202,7 +202,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateLength(MetaEntityAttr attr, string value)
+        private static string? ValidateLength(MetaEntityAttr attr, string value)
         {
             if (attr.MaxLength.HasValue && value.Length > attr.MaxLength.Value) {
                 return $"Ensure this value has at most {attr.MaxLength.Value} characters (it has {value.Length}).";
@@ -215,7 +215,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateRange(MetaEntityAttr attr, string value)
+        private static string? ValidateRange(MetaEntityAttr attr, string value)
         {
             if (!attr.MinValue.HasValue && !attr.MaxValue.HasValue)
                 return null;
@@ -237,7 +237,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateDateRange(MetaEntityAttr attr, string value)
+        private static string? ValidateDateRange(MetaEntityAttr attr, string value)
         {
             if (!attr.MinDateTime.HasValue && !attr.MaxDateTime.HasValue)
                 return null;
@@ -257,7 +257,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateRegex(MetaEntityAttr attr, string value)
+        private static string? ValidateRegex(MetaEntityAttr attr, string value)
         {
             if (string.IsNullOrEmpty(attr.RegexPattern))
                 return null;
@@ -279,7 +279,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             return null;
         }
 
-        private static string ValidateInputType(MetaEntityAttr attr, string value)
+        private static string? ValidateInputType(MetaEntityAttr attr, string value)
         {
             switch (attr.InputType) {
                 case InputTypeHint.Email:

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
@@ -180,8 +180,11 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             if (maxIntegerDigits <= 0)
                 return null;
 
+            // Count digits on the decimal directly — casting to double and using Math.Log10 loses
+            // precision past ~15–17 significant digits (e.g. Precision=20 on SQL Server/Postgres),
+            // which can under-count the digits and silently accept overflowing values.
             var integerPart = decimal.Truncate(Math.Abs(numeric));
-            var digits = integerPart == 0 ? 1 : (int)Math.Floor(Math.Log10((double)integerPart) + 1);
+            var digits = integerPart == 0 ? 1 : integerPart.ToString("F0", CultureInfo.InvariantCulture).Length;
             if (digits > maxIntegerDigits) {
                 return $"Ensure that there are no more than {maxIntegerDigits} digits before the decimal point.";
             }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/Services/FieldValidator.cs
@@ -65,7 +65,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
 
                 var stringValue = token!.Type == JTokenType.String
                     ? token.Value<string>()
-                    : token.ToString();
+                    : FormatTokenInvariant(token);
 
                 if (!attr.IsNullable && string.IsNullOrEmpty(stringValue) && attr.DataType != DataType.Bool) {
                     errors.Add(new FieldError(propName, "This field is required."));
@@ -82,6 +82,21 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
             }
 
             return errors;
+        }
+
+        // Non-String JTokens (numbers, dates, Guids) are produced by ApiDispatcher.ConvertValue after
+        // successful parsing. Converting those back to a string must use InvariantCulture so the
+        // downstream InvariantCulture-based validators (ValidateParse, ValidateDateRange) see the
+        // same format — JValue.ToString() without a provider uses CurrentCulture, which breaks on
+        // non-US locales like pt-BR ("15/06/2028") since InvariantCulture expects "MM/dd/yyyy".
+        private static string FormatTokenInvariant(JToken token)
+        {
+            if (token is JValue jv) {
+                if (jv.Value is IFormattable formattable)
+                    return formattable.ToString(null, CultureInfo.InvariantCulture);
+                return jv.Value?.ToString() ?? string.Empty;
+            }
+            return token.ToString();
         }
 
         private static string? ValidateAttribute(MetaEntityAttr attr, string value)
@@ -264,6 +279,11 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
         {
             if (string.IsNullOrEmpty(attr.RegexPattern))
                 return null;
+            // Regex rules only apply to text fields. A [RegularExpression] accidentally placed on a
+            // numeric/date/Guid property would otherwise run against the already-parsed value and
+            // produce confusing errors; mirrors the gating in ViewRenderer.BuildValidationAttrs.
+            if (!IsStringLikeDataType(attr.DataType))
+                return null;
 
             try {
                 if (!Regex.IsMatch(value, attr.RegexPattern, RegexOptions.None, TimeSpan.FromMilliseconds(250))) {
@@ -284,6 +304,12 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
 
         private static string? ValidateInputType(MetaEntityAttr attr, string value)
         {
+            // Email/Url/Tel/Password hints are meaningful only for text fields. If applied to a
+            // non-string attribute by mistake, the already-parsed typed value must not be
+            // re-validated as free text.
+            if (!IsStringLikeDataType(attr.DataType))
+                return null;
+
             switch (attr.InputType) {
                 case InputTypeHint.Email:
                     if (!new EmailAddressAttribute().IsValid(value))
@@ -308,6 +334,13 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Services
                 || dataType == DataType.Byte
                 || dataType == DataType.Float
                 || dataType == DataType.Currency;
+        }
+
+        private static bool IsStringLikeDataType(DataType dataType)
+        {
+            return dataType == DataType.String
+                || dataType == DataType.Memo
+                || dataType == DataType.FixedChar;
         }
     }
 }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
@@ -14,6 +14,18 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.ViewModels
         public bool IsReadOnly { get; set; }
         public List<FieldViewModel> Fields { get; set; } = new List<FieldViewModel>();
         public Dictionary<string, List<EntityGroupItem>> SidebarGroups { get; set; }
+
+        /// <summary>
+        /// Per-field validation errors, keyed by <see cref="FieldViewModel.PropName"/>.
+        /// When populated, the form is re-rendered with inline error lists.
+        /// </summary>
+        public Dictionary<string, string> Errors { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Raw submitted values from the failed POST, keyed by prop name.
+        /// Used to preserve user input on validation failure (Django's bound-form behavior).
+        /// </summary>
+        public Dictionary<string, object> SubmittedValues { get; set; } = new Dictionary<string, object>();
     }
 
     public class FieldViewModel
@@ -30,5 +42,17 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.ViewModels
         public Type ClrType { get; set; }
         public string DisplayFormat { get; set; }
         public string LookupEntityId { get; set; }
+
+        public int? MaxLength { get; set; }
+        public int? MinLength { get; set; }
+        public decimal? MinValue { get; set; }
+        public decimal? MaxValue { get; set; }
+        public DateTime? MinDateTime { get; set; }
+        public DateTime? MaxDateTime { get; set; }
+        public string RegexPattern { get; set; }
+        public string RegexErrorMessage { get; set; }
+        public int? Precision { get; set; }
+        public int? Scale { get; set; }
+        public InputTypeHint InputType { get; set; } = InputTypeHint.Auto;
     }
 }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
@@ -25,7 +25,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.ViewModels
         /// Raw submitted values from the failed POST, keyed by prop name.
         /// Used to preserve user input on validation failure (Django's bound-form behavior).
         /// </summary>
-        public Dictionary<string, object> SubmittedValues { get; set; } = new Dictionary<string, object>();
+        public Dictionary<string, object?> SubmittedValues { get; set; } = new Dictionary<string, object?>();
     }
 
     public class FieldViewModel
@@ -49,8 +49,8 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.ViewModels
         public decimal? MaxValue { get; set; }
         public DateTime? MinDateTime { get; set; }
         public DateTime? MaxDateTime { get; set; }
-        public string RegexPattern { get; set; }
-        public string RegexErrorMessage { get; set; }
+        public string? RegexPattern { get; set; }
+        public string? RegexErrorMessage { get; set; }
         public int? Precision { get; set; }
         public int? Scale { get; set; }
         public InputTypeHint InputType { get; set; } = InputTypeHint.Auto;

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
@@ -38,7 +38,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.ViewModels
         public bool IsPrimaryKey { get; set; }
         public bool IsRequired { get; set; }
         public bool IsEditable { get; set; }
-        public object Value { get; set; }
+        public object? Value { get; set; }
         public Type ClrType { get; set; }
         public string DisplayFormat { get; set; }
         public string LookupEntityId { get; set; }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/ViewModels/EntityFormViewModel.cs
@@ -38,21 +38,36 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.ViewModels
         public bool IsPrimaryKey { get; set; }
         public bool IsRequired { get; set; }
         public bool IsEditable { get; set; }
+        /// <summary>
+        /// Current value of the field. Sourced from the record on edit, from the submitted POST body on
+        /// validation re-render, or from <see cref="MetaEntityAttr.DefaultValue"/> on initial create.
+        /// </summary>
         public object? Value { get; set; }
         public Type ClrType { get; set; }
         public string DisplayFormat { get; set; }
         public string LookupEntityId { get; set; }
 
+        /// <summary>Maximum string length (maps to HTML <c>maxlength</c>).</summary>
         public int? MaxLength { get; set; }
+        /// <summary>Minimum string length (maps to HTML <c>minlength</c>).</summary>
         public int? MinLength { get; set; }
+        /// <summary>Minimum numeric value (maps to HTML <c>min</c>).</summary>
         public decimal? MinValue { get; set; }
+        /// <summary>Maximum numeric value (maps to HTML <c>max</c>).</summary>
         public decimal? MaxValue { get; set; }
+        /// <summary>Minimum date/time value (maps to HTML <c>min</c> on date inputs).</summary>
         public DateTime? MinDateTime { get; set; }
+        /// <summary>Maximum date/time value (maps to HTML <c>max</c> on date inputs).</summary>
         public DateTime? MaxDateTime { get; set; }
+        /// <summary>Regex pattern for string validation (maps to HTML <c>pattern</c> when HTML5-safe).</summary>
         public string? RegexPattern { get; set; }
+        /// <summary>Error message shown when the regex fails validation.</summary>
         public string? RegexErrorMessage { get; set; }
+        /// <summary>Total digit precision for decimal values.</summary>
         public int? Precision { get; set; }
+        /// <summary>Fractional-digit scale for decimal values.</summary>
         public int? Scale { get; set; }
+        /// <summary>HTML input-type hint (e.g., email, url, password). Defaults to <see cref="InputTypeHint.Auto"/>.</summary>
         public InputTypeHint InputType { get; set; } = InputTypeHint.Auto;
     }
 }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/wwwroot/js/admin-dashboard.js
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/wwwroot/js/admin-dashboard.js
@@ -72,7 +72,21 @@ document.addEventListener('DOMContentLoaded', function () {
             window.opener.dismissRelatedLookupPopup(window, link.getAttribute('data-pk'));
         }
     });
+
+    focusFirstFormError();
 });
+
+function focusFirstFormError() {
+    const errorRow = document.querySelector('.form-row.errors');
+    if (!errorRow) return;
+    if (typeof errorRow.scrollIntoView === 'function') {
+        errorRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+    const input = errorRow.querySelector('input, textarea, select');
+    if (input && typeof input.focus === 'function') {
+        input.focus();
+    }
+}
 
 function showRelatedObjectLookupPopup(triggerLink) {
     const inputId = triggerLink.id.replace(/^lookup_/, '');
@@ -95,5 +109,5 @@ function dismissRelatedLookupPopup(win, chosenId) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { showRelatedObjectLookupPopup, dismissRelatedLookupPopup };
+    module.exports = { showRelatedObjectLookupPopup, dismissRelatedLookupPopup, focusFirstFormError };
 }

--- a/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/wwwroot/js/admin-dashboard.spec.js
+++ b/src/NDjango.Admin.AspNetCore.AdminDashboard.Core/wwwroot/js/admin-dashboard.spec.js
@@ -378,3 +378,52 @@ describe('dismissRelatedLookupPopup', () => {
         expect(mockWin.close).toHaveBeenCalled();
     });
 });
+
+// ─── focusFirstFormError ───
+
+describe('focusFirstFormError', () => {
+    test('focuses the first input inside a .form-row.errors and scrolls it into view', () => {
+        document.body.innerHTML = `
+            <form class="entity-form">
+                <div class="form-row"><label>Name</label><input id="id_name" name="name" /></div>
+                <div class="form-row errors">
+                    <label>Email</label>
+                    <ul class="errorlist"><li>Enter a valid email address.</li></ul>
+                    <input id="id_email" name="email" />
+                </div>
+            </form>
+        `;
+
+        const focusSpy = jest.fn();
+        const scrollSpy = jest.fn();
+        const email = document.getElementById('id_email');
+        email.focus = focusSpy;
+        const errorRow = document.querySelector('.form-row.errors');
+        errorRow.scrollIntoView = scrollSpy;
+
+        loadScript();
+
+        expect(focusSpy).toHaveBeenCalled();
+        expect(scrollSpy).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    });
+
+    test('does nothing when no .form-row.errors is present', () => {
+        document.body.innerHTML = `
+            <form class="entity-form">
+                <div class="form-row"><input id="id_name" /></div>
+            </form>
+        `;
+
+        expect(() => loadScript()).not.toThrow();
+    });
+
+    test('does not throw when error row has no input', () => {
+        document.body.innerHTML = `
+            <div class="form-row errors">
+                <ul class="errorlist"><li>oops</li></ul>
+            </div>
+        `;
+
+        expect(() => loadScript()).not.toThrow();
+    });
+});

--- a/src/NDjango.Admin.Core/Attributes.cs
+++ b/src/NDjango.Admin.Core/Attributes.cs
@@ -36,6 +36,20 @@ namespace NDjango.Admin
         Lookup = 2
     }
 
+    /// <summary>
+    /// Hint for the HTML input type used when rendering a field.
+    /// Maps to HTML5 typed inputs (Django's EmailInput/URLInput/TelInput/ColorInput).
+    /// </summary>
+    public enum InputTypeHint
+    {
+        Auto = 0,
+        Email = 1,
+        Url = 2,
+        Tel = 3,
+        Color = 4,
+        Password = 5
+    }
+
 
     /// <summary>
     /// Represents one entity attribute of data model.
@@ -418,6 +432,39 @@ namespace NDjango.Admin
         /// <value></value>
         public int Size { get; set; }
 
+        /// <summary>Maximum string length (from EF Core or [MaxLength]/[StringLength]).</summary>
+        public int? MaxLength { get; set; }
+
+        /// <summary>Minimum string length. Set only when &gt; 0 to avoid redundant `minlength=0` emission.</summary>
+        public int? MinLength { get; set; }
+
+        /// <summary>Minimum numeric value (from [Range] on numeric types).</summary>
+        public decimal? MinValue { get; set; }
+
+        /// <summary>Maximum numeric value (from [Range] on numeric types).</summary>
+        public decimal? MaxValue { get; set; }
+
+        /// <summary>Minimum DateTime value (from [Range(typeof(DateTime), ...)]).</summary>
+        public DateTime? MinDateTime { get; set; }
+
+        /// <summary>Maximum DateTime value (from [Range(typeof(DateTime), ...)]).</summary>
+        public DateTime? MaxDateTime { get; set; }
+
+        /// <summary>Regex pattern for string validation (from [RegularExpression]).</summary>
+        public string RegexPattern { get; set; }
+
+        /// <summary>Error message to surface when regex validation fails.</summary>
+        public string RegexErrorMessage { get; set; }
+
+        /// <summary>Total digits for decimal values (from EF Core HasPrecision).</summary>
+        public int? Precision { get; set; }
+
+        /// <summary>Fractional digits for decimal values (from EF Core HasPrecision).</summary>
+        public int? Scale { get; set; }
+
+        /// <summary>Hint for which HTML input type to emit.</summary>
+        public InputTypeHint InputType { get; set; } = InputTypeHint.Auto;
+
         /// <summary>
         /// Gets or sets the attribute expression.
         /// </summary>
@@ -506,6 +553,17 @@ namespace NDjango.Admin
             ShowOnView = attr.ShowOnView;
             ShowOnEdit = attr.ShowOnEdit;
             ShowOnCreate = attr.ShowOnCreate;
+            MaxLength = attr.MaxLength;
+            MinLength = attr.MinLength;
+            MinValue = attr.MinValue;
+            MaxValue = attr.MaxValue;
+            MinDateTime = attr.MinDateTime;
+            MaxDateTime = attr.MaxDateTime;
+            RegexPattern = attr.RegexPattern;
+            RegexErrorMessage = attr.RegexErrorMessage;
+            Precision = attr.Precision;
+            Scale = attr.Scale;
+            InputType = attr.InputType;
         }
 
         /// <summary>
@@ -629,6 +687,61 @@ namespace NDjango.Admin
                 await writer.WritePropertyNameAsync("udata", ct).ConfigureAwait(false);
                 await writer.WriteValueAsync(UserData.ToString(), ct).ConfigureAwait(false);
             }
+
+            if (MaxLength.HasValue) {
+                await writer.WritePropertyNameAsync("mxl", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(MaxLength.Value, ct).ConfigureAwait(false);
+            }
+
+            if (MinLength.HasValue) {
+                await writer.WritePropertyNameAsync("mnl", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(MinLength.Value, ct).ConfigureAwait(false);
+            }
+
+            if (MinValue.HasValue) {
+                await writer.WritePropertyNameAsync("mnv", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(MinValue.Value, ct).ConfigureAwait(false);
+            }
+
+            if (MaxValue.HasValue) {
+                await writer.WritePropertyNameAsync("mxv", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(MaxValue.Value, ct).ConfigureAwait(false);
+            }
+
+            if (MinDateTime.HasValue) {
+                await writer.WritePropertyNameAsync("mndt", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(MinDateTime.Value, ct).ConfigureAwait(false);
+            }
+
+            if (MaxDateTime.HasValue) {
+                await writer.WritePropertyNameAsync("mxdt", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(MaxDateTime.Value, ct).ConfigureAwait(false);
+            }
+
+            if (!string.IsNullOrEmpty(RegexPattern)) {
+                await writer.WritePropertyNameAsync("rgx", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(RegexPattern, ct).ConfigureAwait(false);
+            }
+
+            if (!string.IsNullOrEmpty(RegexErrorMessage)) {
+                await writer.WritePropertyNameAsync("rgxm", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(RegexErrorMessage, ct).ConfigureAwait(false);
+            }
+
+            if (Precision.HasValue) {
+                await writer.WritePropertyNameAsync("prec", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(Precision.Value, ct).ConfigureAwait(false);
+            }
+
+            if (Scale.HasValue) {
+                await writer.WritePropertyNameAsync("scl", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync(Scale.Value, ct).ConfigureAwait(false);
+            }
+
+            if (InputType != InputTypeHint.Auto) {
+                await writer.WritePropertyNameAsync("inpt", ct).ConfigureAwait(false);
+                await writer.WriteValueAsync((int)InputType, ct).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -742,6 +855,39 @@ namespace NDjango.Admin
                 case "defVal":
                     var jObj = await JObject.ReadFromAsync(reader, ct).ConfigureAwait(false);
                     DefaultValue = jObj.ToObject<string>();
+                    break;
+                case "mxl":
+                    MaxLength = await reader.ReadAsInt32Async(ct).ConfigureAwait(false);
+                    break;
+                case "mnl":
+                    MinLength = await reader.ReadAsInt32Async(ct).ConfigureAwait(false);
+                    break;
+                case "mnv":
+                    MinValue = await reader.ReadAsDecimalAsync(ct).ConfigureAwait(false);
+                    break;
+                case "mxv":
+                    MaxValue = await reader.ReadAsDecimalAsync(ct).ConfigureAwait(false);
+                    break;
+                case "mndt":
+                    MinDateTime = await reader.ReadAsDateTimeAsync(ct).ConfigureAwait(false);
+                    break;
+                case "mxdt":
+                    MaxDateTime = await reader.ReadAsDateTimeAsync(ct).ConfigureAwait(false);
+                    break;
+                case "rgx":
+                    RegexPattern = await reader.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    break;
+                case "rgxm":
+                    RegexErrorMessage = await reader.ReadAsStringAsync(ct).ConfigureAwait(false);
+                    break;
+                case "prec":
+                    Precision = await reader.ReadAsInt32Async(ct).ConfigureAwait(false);
+                    break;
+                case "scl":
+                    Scale = await reader.ReadAsInt32Async(ct).ConfigureAwait(false);
+                    break;
+                case "inpt":
+                    InputType = (InputTypeHint)(await reader.ReadAsInt32Async(ct).ConfigureAwait(false)).Value;
                     break;
                 default:
                     await reader.ReadAsync(ct).ConfigureAwait(false);

--- a/src/NDjango.Admin.Core/Attributes.cs
+++ b/src/NDjango.Admin.Core/Attributes.cs
@@ -42,11 +42,17 @@ namespace NDjango.Admin
     /// </summary>
     public enum InputTypeHint
     {
+        /// <summary>Default — input type is inferred from the attribute's <see cref="DataType"/>.</summary>
         Auto = 0,
+        /// <summary>HTML5 <c>type="email"</c> — browser performs basic email validation.</summary>
         Email = 1,
+        /// <summary>HTML5 <c>type="url"</c> — browser performs basic URL validation.</summary>
         Url = 2,
+        /// <summary>HTML5 <c>type="tel"</c> — hints numeric keypad on mobile; no format enforced.</summary>
         Tel = 3,
+        /// <summary>HTML5 <c>type="color"</c> — renders the native color picker.</summary>
         Color = 4,
+        /// <summary>HTML5 <c>type="password"</c> — masks input; edit forms leave it blank to preserve the existing value.</summary>
         Password = 5
     }
 

--- a/src/NDjango.Admin.Core/Attributes.cs
+++ b/src/NDjango.Admin.Core/Attributes.cs
@@ -451,10 +451,10 @@ namespace NDjango.Admin
         public DateTime? MaxDateTime { get; set; }
 
         /// <summary>Regex pattern for string validation (from [RegularExpression]).</summary>
-        public string RegexPattern { get; set; }
+        public string? RegexPattern { get; set; }
 
         /// <summary>Error message to surface when regex validation fails.</summary>
-        public string RegexErrorMessage { get; set; }
+        public string? RegexErrorMessage { get; set; }
 
         /// <summary>Total digits for decimal values (from EF Core HasPrecision).</summary>
         public int? Precision { get; set; }

--- a/src/NDjango.Admin.Core/DataUtils.cs
+++ b/src/NDjango.Admin.Core/DataUtils.cs
@@ -1,13 +1,136 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace NDjango.Admin
 {
     public class DataUtils
     {
+        /// <summary>
+        /// Scrapes validation-related DataAnnotations from a property and populates the matching
+        /// fields on <paramref name="attr"/>. Shared by the EF Core and Mongo metadata loaders.
+        /// </summary>
+        /// <remarks>
+        /// Rules mirror Django's field/widget mapping:
+        /// <list type="bullet">
+        /// <item>[Required] is a no-op (handled by IsNullable upstream).</item>
+        /// <item>[MaxLength]/[StringLength] populate MaxLength (smaller wins when both present
+        /// or an EF-derived MaxLength was set earlier).</item>
+        /// <item>[MinLength]/[StringLength] populate MinLength only when the value is greater than 0.</item>
+        /// <item>[Range] populates numeric MinValue/MaxValue, or MinDateTime/MaxDateTime when the
+        /// operand type is DateTime.</item>
+        /// <item>[RegularExpression] populates RegexPattern and RegexErrorMessage.</item>
+        /// <item>[EmailAddress]/[Url]/[Phone] set the InputType hint (no regex generation).</item>
+        /// </list>
+        /// </remarks>
+        public static void ApplyValidationAttributes(MetaEntityAttr attr, PropertyInfo prop)
+        {
+            if (attr == null || prop == null)
+                return;
+
+            var maxLenAttr = prop.GetCustomAttribute<MaxLengthAttribute>();
+            if (maxLenAttr != null) {
+                ApplyMaxLength(attr, maxLenAttr.Length);
+            }
+
+            var stringLenAttr = prop.GetCustomAttribute<StringLengthAttribute>();
+            if (stringLenAttr != null) {
+                ApplyMaxLength(attr, stringLenAttr.MaximumLength);
+                if (stringLenAttr.MinimumLength > 0) {
+                    attr.MinLength = stringLenAttr.MinimumLength;
+                }
+            }
+
+            var minLenAttr = prop.GetCustomAttribute<MinLengthAttribute>();
+            if (minLenAttr != null && minLenAttr.Length > 0) {
+                attr.MinLength = minLenAttr.Length;
+            }
+
+            var rangeAttr = prop.GetCustomAttribute<RangeAttribute>();
+            if (rangeAttr != null) {
+                ApplyRange(attr, rangeAttr);
+            }
+
+            var regexAttr = prop.GetCustomAttribute<RegularExpressionAttribute>();
+            if (regexAttr != null) {
+                attr.RegexPattern = regexAttr.Pattern;
+                if (!string.IsNullOrEmpty(regexAttr.ErrorMessage)) {
+                    attr.RegexErrorMessage = regexAttr.ErrorMessage;
+                }
+            }
+
+            var dataTypeAttr = prop.GetCustomAttribute<DataTypeAttribute>();
+            if (dataTypeAttr != null && dataTypeAttr.DataType == System.ComponentModel.DataAnnotations.DataType.Password) {
+                attr.InputType = InputTypeHint.Password;
+            }
+            else if (IsPasswordPropertyName(prop.Name)) {
+                attr.InputType = InputTypeHint.Password;
+            }
+            else if (prop.GetCustomAttribute<EmailAddressAttribute>() != null) {
+                attr.InputType = InputTypeHint.Email;
+            }
+            else if (prop.GetCustomAttribute<UrlAttribute>() != null) {
+                attr.InputType = InputTypeHint.Url;
+            }
+            else if (prop.GetCustomAttribute<PhoneAttribute>() != null) {
+                attr.InputType = InputTypeHint.Tel;
+            }
+
+            if (attr.InputType == InputTypeHint.Password) {
+                attr.ShowOnView = false;
+            }
+        }
+
+        private static bool IsPasswordPropertyName(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return false;
+            return string.Equals(name, "Password", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(name, "PasswordHash", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static void ApplyMaxLength(MetaEntityAttr attr, int value)
+        {
+            if (value <= 0)
+                return;
+            attr.MaxLength = attr.MaxLength.HasValue
+                ? Math.Min(attr.MaxLength.Value, value)
+                : value;
+        }
+
+        private static void ApplyRange(MetaEntityAttr attr, RangeAttribute rangeAttr)
+        {
+            if (rangeAttr.OperandType == typeof(DateTime)) {
+                if (DateTime.TryParse(rangeAttr.Minimum?.ToString(), CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeLocal, out var minDt))
+                    attr.MinDateTime = minDt;
+                if (DateTime.TryParse(rangeAttr.Maximum?.ToString(), CultureInfo.InvariantCulture,
+                        DateTimeStyles.AssumeLocal, out var maxDt))
+                    attr.MaxDateTime = maxDt;
+                return;
+            }
+
+            try {
+                if (rangeAttr.Minimum != null)
+                    attr.MinValue = Convert.ToDecimal(rangeAttr.Minimum, CultureInfo.InvariantCulture);
+            }
+            catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is OverflowException) {
+                // Unsupported operand type — leave MinValue null.
+            }
+
+            try {
+                if (rangeAttr.Maximum != null)
+                    attr.MaxValue = Convert.ToDecimal(rangeAttr.Maximum, CultureInfo.InvariantCulture);
+            }
+            catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is OverflowException) {
+                // Unsupported operand type — leave MaxValue null.
+            }
+        }
+
         public static string PrettifyName(string name)
         {
 

--- a/src/NDjango.Admin.Core/Exceptions/NDjangoAdminManagerException.cs
+++ b/src/NDjango.Admin.Core/Exceptions/NDjangoAdminManagerException.cs
@@ -6,6 +6,9 @@ namespace NDjango.Admin
     {
         public NDjangoAdminManagerException(string message) : base(message)
         { }
+
+        public NDjangoAdminManagerException(string message, Exception innerException) : base(message, innerException)
+        { }
     }
 
     public class RecordNotFoundException : NDjangoAdminManagerException
@@ -18,6 +21,21 @@ namespace NDjango.Admin
     public class ContainerNotFoundException : NDjangoAdminManagerException
     {
         public ContainerNotFoundException(string sourceId) : base($"Container is not found: {sourceId}")
+        { }
+    }
+
+    public class DataIntegrityException : NDjangoAdminManagerException
+    {
+        public DataIntegrityException(string message) : base(message)
+        { }
+
+        public DataIntegrityException(string message, Exception innerException) : base(message, innerException)
+        { }
+    }
+
+    public class InvalidRecordKeyException : NDjangoAdminManagerException
+    {
+        public InvalidRecordKeyException(string message) : base(message)
         { }
     }
 }

--- a/src/NDjango.Admin.Core/Exceptions/NDjangoAdminManagerException.cs
+++ b/src/NDjango.Admin.Core/Exceptions/NDjangoAdminManagerException.cs
@@ -7,6 +7,7 @@ namespace NDjango.Admin
         public NDjangoAdminManagerException(string message) : base(message)
         { }
 
+        /// <summary>Initializes a new instance with the specified error message and inner exception.</summary>
         public NDjangoAdminManagerException(string message, Exception innerException) : base(message, innerException)
         { }
     }
@@ -24,17 +25,27 @@ namespace NDjango.Admin
         { }
     }
 
+    /// <summary>
+    /// Thrown when a write operation fails a database constraint (unique, foreign key, NOT NULL, length, range).
+    /// The message is translated from the provider-specific error when recognized.
+    /// </summary>
     public class DataIntegrityException : NDjangoAdminManagerException
     {
+        /// <summary>Initializes a new instance with the specified error message.</summary>
         public DataIntegrityException(string message) : base(message)
         { }
 
+        /// <summary>Initializes a new instance with the specified error message and inner exception.</summary>
         public DataIntegrityException(string message, Exception innerException) : base(message, innerException)
         { }
     }
 
+    /// <summary>
+    /// Thrown when a record key supplied via URL or form cannot be converted to the CLR type of the key property.
+    /// </summary>
     public class InvalidRecordKeyException : NDjangoAdminManagerException
     {
+        /// <summary>Initializes a new instance with the specified error message.</summary>
         public InvalidRecordKeyException(string message) : base(message)
         { }
     }

--- a/src/NDjango.Admin.Core/NDjango.Admin.Core.xml
+++ b/src/NDjango.Admin.Core/NDjango.Admin.Core.xml
@@ -26,6 +26,12 @@
             It usually correspond to a navigation property in a model class.
             </summary>
         </member>
+        <member name="T:NDjango.Admin.InputTypeHint">
+            <summary>
+            Hint for the HTML input type used when rendering a field.
+            Maps to HTML5 typed inputs (Django's EmailInput/URLInput/TelInput/ColorInput).
+            </summary>
+        </member>
         <member name="T:NDjango.Admin.MetaEntityAttr">
             <summary>
             Represents one entity attribute of data model.
@@ -226,6 +232,39 @@
             Gets or sets the size of data represented by attribute.
             </summary>
             <value></value>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.MaxLength">
+            <summary>Maximum string length (from EF Core or [MaxLength]/[StringLength]).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.MinLength">
+            <summary>Minimum string length. Set only when &gt; 0 to avoid redundant `minlength=0` emission.</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.MinValue">
+            <summary>Minimum numeric value (from [Range] on numeric types).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.MaxValue">
+            <summary>Maximum numeric value (from [Range] on numeric types).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.MinDateTime">
+            <summary>Minimum DateTime value (from [Range(typeof(DateTime), ...)]).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.MaxDateTime">
+            <summary>Maximum DateTime value (from [Range(typeof(DateTime), ...)]).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.RegexPattern">
+            <summary>Regex pattern for string validation (from [RegularExpression]).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.RegexErrorMessage">
+            <summary>Error message to surface when regex validation fails.</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.Precision">
+            <summary>Total digits for decimal values (from EF Core HasPrecision).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.Scale">
+            <summary>Fractional digits for decimal values (from EF Core HasPrecision).</summary>
+        </member>
+        <member name="P:NDjango.Admin.MetaEntityAttr.InputType">
+            <summary>Hint for which HTML input type to emit.</summary>
         </member>
         <member name="P:NDjango.Admin.MetaEntityAttr.Expr">
             <summary>
@@ -603,6 +642,25 @@
             <param name="encoded">The encoded composite key string from the URL.</param>
             <param name="pkPropNames">The ordered list of PK property names.</param>
             <returns>A dictionary mapping each PK property name to its decoded value.</returns>
+        </member>
+        <member name="M:NDjango.Admin.DataUtils.ApplyValidationAttributes(NDjango.Admin.MetaEntityAttr,System.Reflection.PropertyInfo)">
+            <summary>
+            Scrapes validation-related DataAnnotations from a property and populates the matching
+            fields on <paramref name="attr"/>. Shared by the EF Core and Mongo metadata loaders.
+            </summary>
+            <remarks>
+            Rules mirror Django's field/widget mapping:
+            <list type="bullet">
+            <item>[Required] is a no-op (handled by IsNullable upstream).</item>
+            <item>[MaxLength]/[StringLength] populate MaxLength (smaller wins when both present
+            or an EF-derived MaxLength was set earlier).</item>
+            <item>[MinLength]/[StringLength] populate MinLength only when the value is greater than 0.</item>
+            <item>[Range] populates numeric MinValue/MaxValue, or MinDateTime/MaxDateTime when the
+            operand type is DateTime.</item>
+            <item>[RegularExpression] populates RegexPattern and RegexErrorMessage.</item>
+            <item>[EmailAddress]/[Url]/[Phone] set the InputType hint (no regex generation).</item>
+            </list>
+            </remarks>
         </member>
         <member name="M:NDjango.Admin.DataUtils.ReplaceChar(System.String,System.Char,System.Int32)">
             <summary>

--- a/src/NDjango.Admin.Core/NDjango.Admin.Core.xml
+++ b/src/NDjango.Admin.Core/NDjango.Admin.Core.xml
@@ -32,6 +32,24 @@
             Maps to HTML5 typed inputs (Django's EmailInput/URLInput/TelInput/ColorInput).
             </summary>
         </member>
+        <member name="F:NDjango.Admin.InputTypeHint.Auto">
+            <summary>Default — input type is inferred from the attribute's <see cref="T:NDjango.Admin.DataType"/>.</summary>
+        </member>
+        <member name="F:NDjango.Admin.InputTypeHint.Email">
+            <summary>HTML5 <c>type="email"</c> — browser performs basic email validation.</summary>
+        </member>
+        <member name="F:NDjango.Admin.InputTypeHint.Url">
+            <summary>HTML5 <c>type="url"</c> — browser performs basic URL validation.</summary>
+        </member>
+        <member name="F:NDjango.Admin.InputTypeHint.Tel">
+            <summary>HTML5 <c>type="tel"</c> — hints numeric keypad on mobile; no format enforced.</summary>
+        </member>
+        <member name="F:NDjango.Admin.InputTypeHint.Color">
+            <summary>HTML5 <c>type="color"</c> — renders the native color picker.</summary>
+        </member>
+        <member name="F:NDjango.Admin.InputTypeHint.Password">
+            <summary>HTML5 <c>type="password"</c> — masks input; edit forms leave it blank to preserve the existing value.</summary>
+        </member>
         <member name="T:NDjango.Admin.MetaEntityAttr">
             <summary>
             Represents one entity attribute of data model.
@@ -1091,6 +1109,29 @@
             Initializes a new instance of the <see cref="!:Error"/> class.
             </summary>
             <param name="message">Message.</param>
+        </member>
+        <member name="M:NDjango.Admin.NDjangoAdminManagerException.#ctor(System.String,System.Exception)">
+            <summary>Initializes a new instance with the specified error message and inner exception.</summary>
+        </member>
+        <member name="T:NDjango.Admin.DataIntegrityException">
+            <summary>
+            Thrown when a write operation fails a database constraint (unique, foreign key, NOT NULL, length, range).
+            The message is translated from the provider-specific error when recognized.
+            </summary>
+        </member>
+        <member name="M:NDjango.Admin.DataIntegrityException.#ctor(System.String)">
+            <summary>Initializes a new instance with the specified error message.</summary>
+        </member>
+        <member name="M:NDjango.Admin.DataIntegrityException.#ctor(System.String,System.Exception)">
+            <summary>Initializes a new instance with the specified error message and inner exception.</summary>
+        </member>
+        <member name="T:NDjango.Admin.InvalidRecordKeyException">
+            <summary>
+            Thrown when a record key supplied via URL or form cannot be converted to the CLR type of the key property.
+            </summary>
+        </member>
+        <member name="M:NDjango.Admin.InvalidRecordKeyException.#ctor(System.String)">
+            <summary>Initializes a new instance with the specified error message.</summary>
         </member>
         <member name="T:NDjango.Admin.Export.BasicDataExportSettings">
             <summary>

--- a/src/NDjango.Admin.EntityFrameworkCore.Relational/MetaDataLoader/DbContextMetaDataLoader.cs
+++ b/src/NDjango.Admin.EntityFrameworkCore.Relational/MetaDataLoader/DbContextMetaDataLoader.cs
@@ -474,6 +474,21 @@ namespace NDjango.Admin.EntityFrameworkCore
 
             entityAttr.IsNullable = property.IsNullable;
 
+            var maxLen = property.GetMaxLength();
+            if (maxLen.HasValue && maxLen.Value > 0) {
+                entityAttr.MaxLength = maxLen;
+            }
+
+            var precision = property.GetPrecision();
+            if (precision.HasValue) {
+                entityAttr.Precision = precision;
+            }
+
+            var scale = property.GetScale();
+            if (scale.HasValue) {
+                entityAttr.Scale = scale;
+            }
+
             if (entityAttr.DataType == DataType.Blob) {
                 // HIDE blob fields by default
                 entityAttr.ShowOnCreate = false;
@@ -504,6 +519,11 @@ namespace NDjango.Admin.EntityFrameworkCore
                 var enabled = ApplyMetaEntityAttrAnnotation(entityAttr, propInfo);
                 if (!enabled)
                     return null;
+
+                // Run after the annotation so the password auto-detection
+                // (InputType + ShowOnView=false) is not clobbered by the
+                // annotation's default ShowOnView=true.
+                DataUtils.ApplyValidationAttributes(entityAttr, propInfo);
             }
 
             if (property.ValueGenerated.HasFlag(ValueGenerated.OnAdd) && entityAttr.DefaultValue == null)

--- a/src/NDjango.Admin.EntityFrameworkCore.Relational/NDjango.Admin.EntityFrameworkCore.Relational.csproj
+++ b/src/NDjango.Admin.EntityFrameworkCore.Relational/NDjango.Admin.EntityFrameworkCore.Relational.csproj
@@ -14,8 +14,12 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.*" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="NDjango.Admin.EntityFrameworkCore.Relational.Tests" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\NDjango.Admin.Core\NDjango.Admin.Core.csproj" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
+++ b/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
@@ -147,7 +147,16 @@ namespace NDjango.Admin.Services
             MapProperties(record, props);
 
             await DbContext.AddAsync(record, ct);
-            await DbContext.SaveChangesAsync(ct);
+            try {
+                await DbContext.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException ex) {
+                // Clear the whole tracker (not just this record) so the re-render path can
+                // safely reuse the scoped DbContext without colliding with entities left
+                // in Modified/Added state by the failed SaveChanges.
+                DbContext.ChangeTracker.Clear();
+                throw new DataIntegrityException(TranslateDbUpdateException(ex), ex);
+            }
 
             return record;
         }
@@ -165,7 +174,13 @@ namespace NDjango.Admin.Services
             MapProperties(record, props);
 
             DbContext.Update(record);
-            await DbContext.SaveChangesAsync(ct);
+            try {
+                await DbContext.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException ex) {
+                DbContext.ChangeTracker.Clear();
+                throw new DataIntegrityException(TranslateDbUpdateException(ex), ex);
+            }
 
             return record;
         }
@@ -181,7 +196,13 @@ namespace NDjango.Admin.Services
                     $"({string.Join(";", keys.Select(kv => $"{kv.Key.Name}: {kv.Value}"))})");
 
             DbContext.Remove(record);
-            await DbContext.SaveChangesAsync(ct);
+            try {
+                await DbContext.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException ex) {
+                DbContext.ChangeTracker.Clear();
+                throw new DataIntegrityException(TranslateDbUpdateException(ex), ex);
+            }
         }
 
         public override async Task DeleteRecordsByKeysAsync(string modelId, string sourceId, IReadOnlyList<Dictionary<string, string>> recordKeysList, CancellationToken ct = default)
@@ -236,8 +257,100 @@ namespace NDjango.Admin.Services
         {
             foreach (var entProp in props) {
                 var prop = entity.GetType().GetProperty(entProp.Key);
-                prop?.SetValue(entity, entProp.Value.ToObject(prop.PropertyType));
+                if (prop == null)
+                    continue;
+                try {
+                    prop.SetValue(entity, entProp.Value.ToObject(prop.PropertyType));
+                }
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException
+                    || ex is ArgumentException || ex is Newtonsoft.Json.JsonException
+                    || ex is InvalidCastException) {
+                    throw new DataIntegrityException($"Invalid value for '{prop.Name}'.", ex);
+                }
             }
+        }
+
+        private static string TranslateDbUpdateException(DbUpdateException ex)
+        {
+            // Locale-independent provider error codes only. The previous English-substring fallback
+            // silently degraded on non-English database servers (e.g. a Spanish/Portuguese/German
+            // SQL Server locale would never match "foreign key"/"unique"/"duplicate"), so users on
+            // those servers got an unhelpful generic message. Providers we do not recognize get the
+            // generic message directly — better than a false-positive translation.
+            return TranslateByProviderCode(ex.InnerException)
+                ?? "Unable to save the record due to a data constraint violation.";
+        }
+
+        private static string TranslateByProviderCode(Exception inner)
+        {
+            if (inner == null)
+                return null;
+
+            var typeName = inner.GetType().FullName ?? string.Empty;
+
+            // Explicit allow-list of provider types. An `EndsWith(".SqlException")` match would also
+            // pick up unrelated third-party types that happen to share the suffix (Oracle wrappers,
+            // test doubles, etc.), whose `Number` property — if any — has different semantics.
+            if (typeName.Equals("Microsoft.Data.SqlClient.SqlException", StringComparison.Ordinal)
+                || typeName.Equals("System.Data.SqlClient.SqlException", StringComparison.Ordinal)) {
+                var number = GetIntProperty(inner, "Number");
+                return number switch
+                {
+                    547 => "Referenced record does not exist.",
+                    2601 or 2627 => "A record with the same unique value already exists.",
+                    515 => "A required field is missing.",
+                    8152 or 2628 => "One or more string values exceed the allowed length.",
+                    220 or 232 or 8115 => "One or more numeric values are out of range.",
+                    _ => null
+                };
+            }
+
+            // Npgsql.PostgresException
+            if (typeName.Equals("Npgsql.PostgresException", StringComparison.Ordinal)) {
+                var state = GetStringProperty(inner, "SqlState");
+                return state switch
+                {
+                    "23503" => "Referenced record does not exist.",
+                    "23505" => "A record with the same unique value already exists.",
+                    "23502" => "A required field is missing.",
+                    "22001" => "One or more string values exceed the allowed length.",
+                    "22003" => "One or more numeric values are out of range.",
+                    _ => null
+                };
+            }
+
+            // Microsoft.Data.Sqlite.SqliteException
+            if (typeName.Equals("Microsoft.Data.Sqlite.SqliteException", StringComparison.Ordinal)) {
+                var code = GetIntProperty(inner, "SqliteErrorCode");
+                // SQLITE_CONSTRAINT = 19. Extended codes share the primary 19 but expose extended
+                // values via SqliteExtendedErrorCode. Prefer the extended code when available.
+                var extended = GetIntProperty(inner, "SqliteExtendedErrorCode") ?? code;
+                return extended switch
+                {
+                    787 => "Referenced record does not exist.",       // SQLITE_CONSTRAINT_FOREIGNKEY
+                    1555 or 2067 => "A record with the same unique value already exists.", // PRIMARYKEY / UNIQUE
+                    1299 => "A required field is missing.",           // NOTNULL
+                    _ => null
+                };
+            }
+
+            return null;
+        }
+
+        private static int? GetIntProperty(object obj, string name)
+        {
+            var prop = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            if (prop == null || prop.PropertyType != typeof(int))
+                return null;
+            return (int?)prop.GetValue(obj);
+        }
+
+        private static string GetStringProperty(object obj, string name)
+        {
+            var prop = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            if (prop == null || prop.PropertyType != typeof(string))
+                return null;
+            return (string)prop.GetValue(obj);
         }
 
         private static Dictionary<IProperty, object> GetKeys(IEntityType entityType, Dictionary<string, string> keys)
@@ -250,10 +363,17 @@ namespace NDjango.Admin.Services
                 throw new NDjangoAdminManagerException("Wrong number of key fields");
             }
 
-            return keyProps.ToDictionary(
-                prop => prop,
-                prop => TypeDescriptor.GetConverter(prop.ClrType)
-                                   .ConvertFromString(keys[prop.Name]));
+            var result = new Dictionary<IProperty, object>();
+            foreach (var prop in keyProps) {
+                var raw = keys[prop.Name];
+                try {
+                    result[prop] = TypeDescriptor.GetConverter(prop.ClrType).ConvertFromString(raw);
+                }
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is ArgumentException || ex is NotSupportedException) {
+                    throw new InvalidRecordKeyException($"Invalid value for key '{prop.Name}': '{raw}'.");
+                }
+            }
+            return result;
         }
 
         private static Dictionary<IProperty, object> GetKeys(IEntityType entityType, JObject props)

--- a/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
+++ b/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
@@ -367,7 +367,8 @@ namespace NDjango.Admin.Services
             foreach (var prop in keyProps) {
                 var raw = keys[prop.Name];
                 try {
-                    result[prop] = TypeDescriptor.GetConverter(prop.ClrType).ConvertFromString(raw);
+                    var converted = TypeDescriptor.GetConverter(prop.ClrType).ConvertFromString(raw) ?? throw new InvalidRecordKeyException($"Invalid value for key '{prop.Name}': '{raw}'.");
+                    result[prop] = converted;
                 }
                 catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is ArgumentException || ex is NotSupportedException) {
                     throw new InvalidRecordKeyException($"Invalid value for key '{prop.Name}': '{raw}'.");

--- a/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
+++ b/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
@@ -260,7 +260,7 @@ namespace NDjango.Admin.Services
                 if (prop == null)
                     continue;
                 try {
-                    prop.SetValue(entity, entProp.Value.ToObject(prop.PropertyType));
+                    prop.SetValue(entity, entProp.Value?.ToObject(prop.PropertyType));
                 }
                 catch (Exception ex) when (ex is FormatException || ex is OverflowException
                     || ex is ArgumentException || ex is Newtonsoft.Json.JsonException
@@ -281,7 +281,7 @@ namespace NDjango.Admin.Services
                 ?? "Unable to save the record due to a data constraint violation.";
         }
 
-        private static string TranslateByProviderCode(Exception inner)
+        private static string? TranslateByProviderCode(Exception? inner)
         {
             if (inner == null)
                 return null;
@@ -345,12 +345,12 @@ namespace NDjango.Admin.Services
             return (int?)prop.GetValue(obj);
         }
 
-        private static string GetStringProperty(object obj, string name)
+        private static string? GetStringProperty(object obj, string name)
         {
             var prop = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
             if (prop == null || prop.PropertyType != typeof(string))
                 return null;
-            return (string)prop.GetValue(obj);
+            return (string?)prop.GetValue(obj);
         }
 
         private static Dictionary<IProperty, object> GetKeys(IEntityType entityType, Dictionary<string, string> keys)

--- a/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
+++ b/src/NDjango.Admin.EntityFrameworkCore.Relational/Services/NDjangoAdminManagerEF.cs
@@ -270,7 +270,7 @@ namespace NDjango.Admin.Services
             }
         }
 
-        private static string TranslateDbUpdateException(DbUpdateException ex)
+        internal static string TranslateDbUpdateException(DbUpdateException ex)
         {
             // Locale-independent provider error codes only. The previous English-substring fallback
             // silently degraded on non-English database servers (e.g. a Spanish/Portuguese/German
@@ -281,7 +281,7 @@ namespace NDjango.Admin.Services
                 ?? "Unable to save the record due to a data constraint violation.";
         }
 
-        private static string? TranslateByProviderCode(Exception? inner)
+        internal static string? TranslateByProviderCode(Exception? inner)
         {
             if (inner == null)
                 return null;

--- a/src/NDjango.Admin.MongoDB/MongoMetaDataLoader.cs
+++ b/src/NDjango.Admin.MongoDB/MongoMetaDataLoader.cs
@@ -220,6 +220,10 @@ namespace NDjango.Admin.MongoDB
                 entityAttr.ShowOnView = false;
             }
 
+            // Run after the visibility defaults so the password auto-detection
+            // (InputType + ShowOnView=false) is not clobbered by ShowOnView=true above.
+            DataUtils.ApplyValidationAttributes(entityAttr, property);
+
             // Handle enum types
             var actualType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
             if (actualType.IsEnum) {

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NDjango.Admin.AspNetCore.AdminDashboard.Authentication;
+using NDjango.Admin.AspNetCore.AdminDashboard.Authentication.Storage;
+using NDjango.Admin.AspNetCore.AdminDashboard.Authorization;
+using NDjango.Admin.AspNetCore.AdminDashboard.Tests.Fixtures;
+using Xunit;
+
+namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
+{
+    public class AuthUserUpdateTests : IAsyncLifetime, IDisposable
+    {
+        private readonly string _dbName;
+        private readonly string _connectionString;
+        private IHost _host;
+
+        private static readonly string ConnectionStringTemplate =
+            TestConnectionHelper.ConnectionStringTemplate;
+
+        public AuthUserUpdateTests()
+        {
+            _dbName = $"NDjangoAdminAuthUserUpdateTest_{Guid.NewGuid():N}";
+            _connectionString = string.Format(ConnectionStringTemplate, _dbName);
+        }
+
+        public async Task InitializeAsync()
+        {
+            EnsureDatabase(_connectionString);
+
+            _host = new HostBuilder()
+                .ConfigureWebHost(webBuilder =>
+                {
+                    webBuilder
+                        .UseTestServer()
+                        .ConfigureServices(services =>
+                        {
+                            services.AddDbContext<TestDbContext>(options =>
+                                options.UseSqlServer(_connectionString));
+                            services.AddNDjangoAdminDashboard<TestDbContext>(
+                                new AdminDashboardOptions
+                                {
+                                    Authorization = new[] { new AllowAllAdminDashboardAuthorizationFilter() },
+                                    DashboardTitle = "Test Admin",
+                                    RequireAuthentication = true,
+                                    CreateDefaultAdminUser = true,
+                                    DefaultAdminPassword = "admin",
+                                });
+                        })
+                        .Configure(app =>
+                        {
+                            app.UseNDjangoAdminDashboard("/admin");
+                        });
+                })
+                .Start();
+
+            var readiness = _host.Services.GetRequiredService<Authentication.AuthBootstrapReadinessState>();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+            await readiness.WaitForReadyAsync(cts.Token);
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        private static void EnsureDatabase(string connectionString)
+        {
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlServer(connectionString)
+                .Options;
+            using var context = new TestDbContext(options);
+            context.Database.EnsureCreated();
+        }
+
+        [Fact]
+        public async Task UpdatePost_WithBlankPassword_PreservesExistingHashAsync()
+        {
+            // Arrange — create a user, capture its initial hash
+            var client = _host.GetTestClient();
+            var cookie = await LoginAsync(client, "admin", "admin");
+
+            var createForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Username", "keeppass_user"),
+                new KeyValuePair<string, string>("Password", "originalPass123"),
+                new KeyValuePair<string, string>("_save_action", "continue"),
+            });
+            var createReq = new HttpRequestMessage(HttpMethod.Post, "/admin/AuthUser/add/") { Content = createForm };
+            createReq.Headers.Add("Cookie", cookie);
+            var createResp = await client.SendAsync(createReq);
+            Assert.Equal(HttpStatusCode.Redirect, createResp.StatusCode);
+            var userId = ExtractIdFromRedirect(createResp.Headers.Location.ToString(), "AuthUser");
+
+            var beforeUser = await GetAuthUserAsync("keeppass_user");
+            Assert.NotNull(beforeUser);
+            var originalHash = beforeUser.Value.PasswordHash;
+            Assert.False(string.IsNullOrEmpty(originalHash));
+
+            // Act — update with empty password; change only IsSuperuser flag
+            var updateForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Username", "keeppass_user"),
+                new KeyValuePair<string, string>("Password", ""),
+                new KeyValuePair<string, string>("IsSuperuser", "true"),
+                new KeyValuePair<string, string>("IsActive", "true"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+            var updateReq = new HttpRequestMessage(HttpMethod.Post, $"/admin/AuthUser/{userId}/change/") { Content = updateForm };
+            updateReq.Headers.Add("Cookie", cookie);
+            var updateResp = await client.SendAsync(updateReq);
+
+            // Assert — redirect (no validation failure), password hash unchanged
+            Assert.Equal(HttpStatusCode.Redirect, updateResp.StatusCode);
+
+            var afterUser = await GetAuthUserAsync("keeppass_user");
+            Assert.NotNull(afterUser);
+            Assert.Equal(originalHash, afterUser.Value.PasswordHash);
+            Assert.True(afterUser.Value.IsSuperuser);
+        }
+
+        [Fact]
+        public async Task UpdatePost_WithNewPassword_UpdatesHashAsync()
+        {
+            // Arrange
+            var client = _host.GetTestClient();
+            var cookie = await LoginAsync(client, "admin", "admin");
+
+            var createForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Username", "changepass_user"),
+                new KeyValuePair<string, string>("Password", "firstPass123"),
+                new KeyValuePair<string, string>("_save_action", "continue"),
+            });
+            var createReq = new HttpRequestMessage(HttpMethod.Post, "/admin/AuthUser/add/") { Content = createForm };
+            createReq.Headers.Add("Cookie", cookie);
+            var createResp = await client.SendAsync(createReq);
+            var userId = ExtractIdFromRedirect(createResp.Headers.Location.ToString(), "AuthUser");
+
+            var beforeUser = await GetAuthUserAsync("changepass_user");
+            Assert.NotNull(beforeUser);
+            var originalHash = beforeUser.Value.PasswordHash;
+
+            // Act — update with non-empty password; hash should change
+            var updateForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Username", "changepass_user"),
+                new KeyValuePair<string, string>("Password", "brandNewPass999"),
+                new KeyValuePair<string, string>("IsActive", "true"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+            var updateReq = new HttpRequestMessage(HttpMethod.Post, $"/admin/AuthUser/{userId}/change/") { Content = updateForm };
+            updateReq.Headers.Add("Cookie", cookie);
+            var updateResp = await client.SendAsync(updateReq);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Redirect, updateResp.StatusCode);
+
+            var afterUser = await GetAuthUserAsync("changepass_user");
+            Assert.NotNull(afterUser);
+            Assert.NotEqual(originalHash, afterUser.Value.PasswordHash);
+        }
+
+        private static string ExtractIdFromRedirect(string locationHeader, string entity)
+        {
+            var match = Regex.Match(locationHeader, $@"/admin/{entity}/(\d+)/change/");
+            Assert.True(match.Success, $"Expected redirect to /admin/{entity}/{{id}}/change/ but got: {locationHeader}");
+            return match.Groups[1].Value;
+        }
+
+        private async Task<(string Id, string Username, string PasswordHash, bool IsSuperuser, bool IsActive)?> GetAuthUserAsync(string username)
+        {
+            var authOptions = new DbContextOptionsBuilder<AuthDbContext>()
+                .UseSqlServer(_connectionString)
+                .Options;
+
+            using var authDbContext = new AuthDbContext(authOptions);
+            var queries = new AuthStorageQueries(authDbContext);
+            return await queries.GetUserByUsernameAsync(username);
+        }
+
+        private async Task<string> LoginAsync(HttpClient client, string username, string password)
+        {
+            var formContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("username", username),
+                new KeyValuePair<string, string>("password", password),
+            });
+
+            var loginResponse = await client.PostAsync("/admin/login/", formContent);
+            foreach (var header in loginResponse.Headers.GetValues("Set-Cookie"))
+            {
+                if (header.Contains(".NDjango.Admin.Auth"))
+                    return header.Split(';')[0];
+            }
+            return null;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                var masterConn = string.Format(ConnectionStringTemplate, "master");
+                var options = new DbContextOptionsBuilder<TestDbContext>()
+                    .UseSqlServer(masterConn)
+                    .Options;
+                using var context = new TestDbContext(options);
+                context.Database.ExecuteSqlRaw(
+                    $"IF DB_ID('{_dbName}') IS NOT NULL BEGIN ALTER DATABASE [{_dbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE [{_dbName}]; END");
+            }
+            catch { }
+
+            _host?.Dispose();
+        }
+    }
+}

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
@@ -189,6 +189,53 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
             Assert.NotEqual(originalHash, afterUser.Value.PasswordHash);
         }
 
+        [Fact]
+        public async Task UpdatePost_WithWhitespaceOnlyPassword_UpdatesHashAsync()
+        {
+            // Arrange — a whitespace-only password is a deliberate (if weak) value the user submitted.
+            // StripBlankPasswordFields must use IsNullOrEmpty (not IsNullOrWhiteSpace) so the value
+            // reaches HashPasswordInProps and replaces the stored hash; switching to IsNullOrWhiteSpace
+            // would silently keep the old hash while the user thinks they set a new password.
+            var client = _host.GetTestClient();
+            var cookie = await LoginAsync(client, "admin", "admin");
+
+            var createForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Username", "whitespacepass_user"),
+                new KeyValuePair<string, string>("Password", "originalPass123"),
+                new KeyValuePair<string, string>("_save_action", "continue"),
+            });
+            var createReq = new HttpRequestMessage(HttpMethod.Post, "/admin/AuthUser/add/") { Content = createForm };
+            createReq.Headers.Add("Cookie", cookie);
+            var createResp = await client.SendAsync(createReq);
+            var userId = ExtractIdFromRedirect(createResp.Headers.Location.ToString(), "AuthUser");
+
+            var beforeUser = await GetAuthUserAsync("whitespacepass_user");
+            Assert.NotNull(beforeUser);
+            var originalHash = beforeUser.Value.PasswordHash;
+
+            // Act — submit three spaces as the password
+            var updateForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Username", "whitespacepass_user"),
+                new KeyValuePair<string, string>("Password", "   "),
+                new KeyValuePair<string, string>("IsActive", "true"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+            var updateReq = new HttpRequestMessage(HttpMethod.Post, $"/admin/AuthUser/{userId}/change/") { Content = updateForm };
+            updateReq.Headers.Add("Cookie", cookie);
+            var updateResp = await client.SendAsync(updateReq);
+
+            // Assert — redirect (whitespace passes [Required] since it is not empty) and the hash must
+            // be different from the original, proving the whitespace was NOT stripped from props.
+            Assert.Equal(HttpStatusCode.Redirect, updateResp.StatusCode);
+
+            var afterUser = await GetAuthUserAsync("whitespacepass_user");
+            Assert.NotNull(afterUser);
+            Assert.NotEqual(originalHash, afterUser.Value.PasswordHash);
+            Assert.False(string.IsNullOrEmpty(afterUser.Value.PasswordHash));
+        }
+
         private static string ExtractIdFromRedirect(string locationHeader, string entity)
         {
             var match = Regex.Match(locationHeader, $@"/admin/{entity}/(\d+)/change/");

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
@@ -218,6 +218,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
             catch { }
 
             _host?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/AuthUserUpdateTests.cs
@@ -81,6 +81,27 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
         }
 
         [Fact]
+        public async Task CreateForm_PasswordField_RendersAsPasswordInputWithNewPasswordAutocompleteAsync()
+        {
+            // Arrange — AuthUser.PasswordHash maps to a Password input by convention. The rendered HTML
+            // must use type="password" (not text) and autocomplete="new-password" to keep the cleartext
+            // out of form history and prevent the browser from pre-filling a stored credential.
+            var client = _host.GetTestClient();
+            var cookie = await LoginAsync(client, "admin", "admin");
+            var request = new HttpRequestMessage(HttpMethod.Get, "/admin/AuthUser/add/");
+            request.Headers.Add("Cookie", cookie);
+
+            // Act
+            var response = await client.SendAsync(request);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("type=\"password\"", html);
+            Assert.Contains("autocomplete=\"new-password\"", html);
+        }
+
+        [Fact]
         public async Task UpdatePost_WithBlankPassword_PreservesExistingHashAsync()
         {
             // Arrange — create a user, capture its initial hash

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/CreateEdgeCaseTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/CreateEdgeCaseTests.cs
@@ -121,7 +121,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
         }
 
         [Fact]
-        public async Task PostCreate_InvalidForeignKey_ThrowsAsync()
+        public async Task PostCreate_InvalidForeignKey_Returns400WithErrorAsync()
         {
             // Arrange
             var formData = new FormUrlEncodedContent(new[]
@@ -132,9 +132,13 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
                 new KeyValuePair<string, string>("_save_action", "save"),
             });
 
-            // Act & Assert
-            await Assert.ThrowsAnyAsync<Exception>(
-                () => _client.PostAsync("/admin/Restaurant/add/", formData));
+            // Act
+            var response = await _client.PostAsync("/admin/Restaurant/add/", formData);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("Referenced record does not exist", html);
         }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/DeleteEdgeCaseTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/DeleteEdgeCaseTests.cs
@@ -60,9 +60,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
             Assert.Equal(HttpStatusCode.OK, responseA.StatusCode);
             Assert.Contains("DeleteTest_A", htmlA);
 
-            // Verify B was deleted (fetching it should throw or return error)
-            await Assert.ThrowsAnyAsync<Exception>(() =>
-                _client.GetAsync($"/admin/Ingredient/{ids[1]}/change/"));
+            // Verify B was deleted (fetching it returns 404)
+            var responseB = await _client.GetAsync($"/admin/Ingredient/{ids[1]}/change/");
+            Assert.Equal(HttpStatusCode.NotFound, responseB.StatusCode);
 
             // Verify C still exists
             var responseC = await _client.GetAsync($"/admin/Ingredient/{ids[2]}/change/");
@@ -72,7 +72,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
         }
 
         [Fact]
-        public async Task PostDelete_AlreadyDeletedRecord_ThrowsAsync()
+        public async Task PostDelete_AlreadyDeletedRecord_Returns404Async()
         {
             // Arrange
             var formData = new FormUrlEncodedContent(new[]
@@ -88,19 +88,25 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
                 new FormUrlEncodedContent(Array.Empty<KeyValuePair<string, string>>()));
             Assert.Equal(HttpStatusCode.Redirect, firstDelete.StatusCode);
 
-            // Act & Assert
-            await Assert.ThrowsAnyAsync<Exception>(() => _client.PostAsync(
+            // Act
+            var secondDelete = await _client.PostAsync(
                 $"/admin/Ingredient/{id}/delete/",
-                new FormUrlEncodedContent(Array.Empty<KeyValuePair<string, string>>())));
+                new FormUrlEncodedContent(Array.Empty<KeyValuePair<string, string>>()));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, secondDelete.StatusCode);
         }
 
         [Fact]
-        public async Task PostDelete_NonExistentId_ThrowsAsync()
+        public async Task PostDelete_NonExistentId_Returns404Async()
         {
-            // Arrange & Act & Assert
-            await Assert.ThrowsAnyAsync<Exception>(() => _client.PostAsync(
+            // Arrange / Act
+            var response = await _client.PostAsync(
                 "/admin/Ingredient/999999/delete/",
-                new FormUrlEncodedContent(Array.Empty<KeyValuePair<string, string>>())));
+                new FormUrlEncodedContent(Array.Empty<KeyValuePair<string, string>>()));
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Fact]

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/UpdateEdgeCaseTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/UpdateEdgeCaseTests.cs
@@ -67,7 +67,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
         }
 
         [Fact]
-        public async Task PostUpdate_NonExistentId_ThrowsAsync()
+        public async Task PostUpdate_NonExistentId_Returns404Async()
         {
             // Arrange
             var formData = new FormUrlEncodedContent(new[]
@@ -76,9 +76,11 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
                 new KeyValuePair<string, string>("_save_action", "save"),
             });
 
-            // Act & Assert
-            await Assert.ThrowsAnyAsync<Exception>(
-                () => _client.PostAsync("/admin/Ingredient/999999/change/", formData));
+            // Act
+            var response = await _client.PostAsync("/admin/Ingredient/999999/change/", formData);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
         [Fact]

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/ValidationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/ValidationTests.cs
@@ -1,0 +1,516 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.TestHost;
+
+using NDjango.Admin.AspNetCore.AdminDashboard.Tests.Fixtures;
+
+using Xunit;
+
+namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
+{
+    public class ValidationTests : IClassFixture<AdminDashboardFixture>
+    {
+        private readonly HttpClient _client;
+
+        public ValidationTests(AdminDashboardFixture fixture)
+        {
+            _client = fixture.GetTestHost().GetTestClient();
+        }
+
+        [Fact]
+        public async Task CreateForm_StringWithMaxLength_EmitsMaxlengthAttributeAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/ValidatedProduct/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("maxlength=\"50\"", html);
+        }
+
+        [Fact]
+        public async Task CreateForm_IntRange_EmitsMinMaxAttributesAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/ValidatedProduct/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("min=\"1\"", html);
+            Assert.Contains("max=\"1000\"", html);
+        }
+
+        [Fact]
+        public async Task CreateForm_RegexWithoutInlineFlags_EmitsPatternAttributeAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/ValidatedProduct/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("pattern=\"\\d{5}\"", html);
+            Assert.Contains("title=\"Must be 5 digits\"", html);
+        }
+
+        [Fact]
+        public async Task CreateForm_RegexWithInlineFlags_DoesNotEmitPatternAttributeAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/ValidatedProduct/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.DoesNotContain("(?i)", html);
+        }
+
+        [Fact]
+        public async Task CreateForm_EmailField_RendersAsEmailInputAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/ValidatedProduct/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("type=\"email\"", html);
+        }
+
+        [Fact]
+        public async Task CreateForm_UrlField_RendersAsUrlInputAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/ValidatedProduct/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Contains("type=\"url\"", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_MissingRequiredField_Returns400WithErrorlistAsync()
+        {
+            // Arrange
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Quantity", "5"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("errorlist", html);
+            Assert.Contains("This field is required.", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_StringExceedsMaxLength_Returns400WithAtMostMessageAsync()
+        {
+            // Arrange — Name is capped at 50 chars; submit 60
+            var longName = new string('x', 60);
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", longName),
+                new KeyValuePair<string, string>("Quantity", "5"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("at most 50 characters", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_QuantityOutOfRange_Returns400Async()
+        {
+            // Arrange
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "MyProduct"),
+                new KeyValuePair<string, string>("Quantity", "5000"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("less than or equal to 1000", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_InvalidEmail_Returns400Async()
+        {
+            // Arrange
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Prod"),
+                new KeyValuePair<string, string>("Quantity", "5"),
+                new KeyValuePair<string, string>("Email", "not-an-email"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("valid email", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_RegexWithInlineFlags_ServerStillEnforcesAsync()
+        {
+            // Arrange — CaseInsensitive requires "allowed" (pattern skipped from HTML but
+            // FieldValidator still runs it).
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Prod"),
+                new KeyValuePair<string, string>("Quantity", "5"),
+                new KeyValuePair<string, string>("CaseInsensitive", "disallowed"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task CreatePost_InvalidSubmission_PreservesSubmittedValuesAsync()
+        {
+            // Arrange — valid Name but invalid Quantity; Name should round-trip.
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "ShouldStickAround"),
+                new KeyValuePair<string, string>("Quantity", "99999"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("ShouldStickAround", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_AllValidFields_RedirectsAsync()
+        {
+            // Arrange
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Valid"),
+                new KeyValuePair<string, string>("Quantity", "42"),
+                new KeyValuePair<string, string>("Email", "ok@example.com"),
+                new KeyValuePair<string, string>("Website", "https://example.com"),
+                new KeyValuePair<string, string>("PostalCode", "12345"),
+                new KeyValuePair<string, string>("CaseInsensitive", "ALLOWED"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task EditForm_NonExistentId_Returns404Async()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/Category/99999/change/");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task EditForm_NonNumericId_Returns404Async()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/Category/abc/change/");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteForm_NonExistentId_Returns404Async()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/Category/99999/delete/");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeleteForm_NonNumericId_Returns404Async()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/Category/abc/delete/");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task List_InvalidSortColumn_FallsBackToDefaultSortAsync()
+        {
+            // Arrange
+            // No per-test setup required; _client is created once in the constructor.
+
+            // Act
+            var response = await _client.GetAsync("/admin/Category/?sort=NotAColumn");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("Italian", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_NonExistentForeignKey_Returns400WithErrorAsync()
+        {
+            // Arrange — FK to a Restaurant that doesn't exist (9999)
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Website", "https://orphan.example.com"),
+                new KeyValuePair<string, string>("Phone", "555-0199"),
+                new KeyValuePair<string, string>("RestaurantId", "9999"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/RestaurantProfile/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("Referenced record does not exist", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_UniqueConstraintViolation_Returns400WithErrorAsync()
+        {
+            // Arrange — seed already has a RestaurantProfile for Restaurant 1; add another for same FK
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Website", "https://dup.example.com"),
+                new KeyValuePair<string, string>("Phone", "555-9999"),
+                new KeyValuePair<string, string>("RestaurantId", "1"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/RestaurantProfile/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("already exists", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_DecimalOverflowPrecision_Returns400Async()
+        {
+            // Arrange — MenuItem.Price is decimal(10,2); 999999999.99 has 9 integer digits
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Overflow"),
+                new KeyValuePair<string, string>("Price", "999999999.99"),
+                new KeyValuePair<string, string>("RestaurantId", "1"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/MenuItem/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("digits before the decimal point", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_NonNumericDecimal_Returns400Async()
+        {
+            // Arrange
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Bad Price"),
+                new KeyValuePair<string, string>("Price", "not-a-number"),
+                new KeyValuePair<string, string>("RestaurantId", "1"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/MenuItem/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("valid number", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_InvalidGuidScalar_Returns400Async()
+        {
+            // Arrange — Gift.TrackingCode is a Guid
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test Gift"),
+                new KeyValuePair<string, string>("TrackingCode", "not-a-guid"),
+                new KeyValuePair<string, string>("Price", "1.00"),
+                new KeyValuePair<string, string>("Barcode", "1"),
+                new KeyValuePair<string, string>("Weight", "1"),
+                new KeyValuePair<string, string>("Rating", "1"),
+                new KeyValuePair<string, string>("QuantityInStock", "1"),
+                new KeyValuePair<string, string>("MinAge", "1"),
+                new KeyValuePair<string, string>("ShippedAt", "2025-01-01"),
+                new KeyValuePair<string, string>("PreparationTime", "00:10:00"),
+                new KeyValuePair<string, string>("ExpirationDate", "2025-12-31"),
+                new KeyValuePair<string, string>("AvailableFrom", "08:00"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/Gift/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("valid UUID", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_ByteOverflow_Returns400Async()
+        {
+            // Arrange — Gift.MinAge is a byte (0-255); submit 999
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Test Gift"),
+                new KeyValuePair<string, string>("TrackingCode", Guid.NewGuid().ToString()),
+                new KeyValuePair<string, string>("Price", "1.00"),
+                new KeyValuePair<string, string>("Barcode", "1"),
+                new KeyValuePair<string, string>("Weight", "1"),
+                new KeyValuePair<string, string>("Rating", "1"),
+                new KeyValuePair<string, string>("QuantityInStock", "1"),
+                new KeyValuePair<string, string>("MinAge", "999"),
+                new KeyValuePair<string, string>("ShippedAt", "2025-01-01"),
+                new KeyValuePair<string, string>("PreparationTime", "00:10:00"),
+                new KeyValuePair<string, string>("ExpirationDate", "2025-12-31"),
+                new KeyValuePair<string, string>("AvailableFrom", "08:00"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/Gift/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("between 0 and 255", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_StringWithNullByte_Returns400WithInvalidCharactersErrorAsync()
+        {
+            // Arrange — ASP.NET Core FormPipeReader rejects %00 in form decode; surface a 400 instead of propagating HTTP 500
+            var form = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "Good\0Name"),
+                new KeyValuePair<string, string>("Quantity", "5"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", form);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("invalid characters", html);
+        }
+
+        [Fact]
+        public async Task CreatePost_JsonContentType_Returns400WithInvalidContentTypeErrorAsync()
+        {
+            // Arrange — ReadFormAsync throws InvalidOperationException when Content-Type is not form; surface a 400 instead of HTTP 500
+            var content = new StringContent("{\"Name\":\"Test\",\"Quantity\":1}", System.Text.Encoding.UTF8, "application/json");
+
+            // Act
+            var response = await _client.PostAsync("/admin/ValidatedProduct/add/", content);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("invalid content type", html);
+        }
+
+        [Fact]
+        public async Task UpdatePost_JsonContentType_Returns400WithInvalidContentTypeErrorAsync()
+        {
+            // Arrange — use a pre-seeded record; the content-type guard must run before any DB work
+            var content = new StringContent("{\"Name\":\"Changed\"}", System.Text.Encoding.UTF8, "application/json");
+
+            // Act
+            var response = await _client.PostAsync("/admin/Category/1/change/", content);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("invalid content type", html);
+        }
+    }
+}

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/ValidationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/ValidationTests.cs
@@ -109,6 +109,35 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
         }
 
         [Fact]
+        public async Task CreateForm_DecimalWithScale_EmitsStepMatchingScaleAsync()
+        {
+            // Arrange — MenuItem.Price is configured as decimal(10,2); step should match the scale.
+
+            // Act
+            var response = await _client.GetAsync("/admin/MenuItem/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("step=\"0.01\"", html);
+        }
+
+        [Fact]
+        public async Task CreateForm_FloatWithoutScale_EmitsStepAnyAsync()
+        {
+            // Arrange — Gift.Weight is a double with no HasPrecision, so the step must fall back to "any"
+            // so browsers accept arbitrary fractional digits instead of rejecting non-integer input.
+
+            // Act
+            var response = await _client.GetAsync("/admin/Gift/add/");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Contains("step=\"any\"", html);
+        }
+
+        [Fact]
         public async Task CreatePost_MissingRequiredField_Returns400WithErrorlistAsync()
         {
             // Arrange

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/ValidationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityCrudTests/ValidationTests.cs
@@ -512,5 +512,76 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityCrudTests
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
             Assert.Contains("invalid content type", html);
         }
+
+        [Fact]
+        public async Task UpdatePost_ValidationFailure_Returns400AndRendersFormWithErrorsAsync()
+        {
+            // Arrange — seed a Category, then attempt to update it with an invalid (too long) name.
+            // Covers the RazorViewDispatcher.RenderEntityFormWithErrorsAsync edit-path: must set HTTP 400
+            // and re-render the form including the errorlist, not redirect.
+            var createForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "UpdateValidation_" + Guid.NewGuid().ToString("N")[..8]),
+                new KeyValuePair<string, string>("Quantity", "10"),
+                new KeyValuePair<string, string>("_save_action", "continue"),
+            });
+            var createResp = await _client.PostAsync("/admin/ValidatedProduct/add/", createForm);
+            Assert.Equal(HttpStatusCode.Redirect, createResp.StatusCode);
+            var id = System.Text.RegularExpressions.Regex
+                .Match(createResp.Headers.Location.ToString(), @"/admin/ValidatedProduct/(\d+)/change/")
+                .Groups[1].Value;
+
+            var longName = new string('z', 60);
+            var updateForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", longName),
+                new KeyValuePair<string, string>("Quantity", "10"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync($"/admin/ValidatedProduct/{id}/change/", updateForm);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("errorlist", html);
+            Assert.Contains("at most 50 characters", html);
+            Assert.Contains("entity-form", html); // confirms a bound form re-render, not a redirect
+        }
+
+        [Fact]
+        public async Task UpdatePost_ValidationFailure_PreservesSubmittedValuesAsync()
+        {
+            // Arrange — on edit, a failed validation must re-render the form with the user's submitted
+            // values (not the stored record's values), mirroring Django's bound-form behavior.
+            var uniqueValidPart = "SubmittedOnEdit_" + Guid.NewGuid().ToString("N")[..6];
+            var createForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", uniqueValidPart),
+                new KeyValuePair<string, string>("Quantity", "10"),
+                new KeyValuePair<string, string>("_save_action", "continue"),
+            });
+            var createResp = await _client.PostAsync("/admin/ValidatedProduct/add/", createForm);
+            var id = System.Text.RegularExpressions.Regex
+                .Match(createResp.Headers.Location.ToString(), @"/admin/ValidatedProduct/(\d+)/change/")
+                .Groups[1].Value;
+
+            var updateForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "KeepThisTyped"),
+                new KeyValuePair<string, string>("Quantity", "99999"),
+                new KeyValuePair<string, string>("_save_action", "save"),
+            });
+
+            // Act
+            var response = await _client.PostAsync($"/admin/ValidatedProduct/{id}/change/", updateForm);
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Contains("KeepThisTyped", html);
+            Assert.DoesNotContain(uniqueValidPart, html);
+        }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityListTests/PaginationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/EntityListTests/PaginationTests.cs
@@ -143,5 +143,51 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.EntityListTests
             // Assert
             Assert.Contains("<span class=\"this-page\">2</span>", html);
         }
+
+        [Fact]
+        public async Task GetIngredientList_NegativePage_DoesNotThrowAsync()
+        {
+            // Arrange & Act — negative page would produce negative offset and crash EF Core Skip()
+            var response = await _client.GetAsync(ScopedListUrl + "&page=-1");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetIngredientList_ExtremelyLargePage_DoesNotOverflowOffsetAsync()
+        {
+            // Arrange & Act — (page-1)*pageSize would overflow int without long arithmetic; expect a graceful empty render
+            var response = await _client.GetAsync(ScopedListUrl + "&page=99999999");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(0, CountTableBodyRows(html));
+        }
+
+        [Fact]
+        public async Task GetIngredientList_ZeroPage_ClampsToFirstPageAsync()
+        {
+            // Arrange & Act
+            var response = await _client.GetAsync(ScopedListUrl + "&page=0");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(BulkDataFixture.DefaultPageSize, CountTableBodyRows(html));
+        }
+
+        [Fact]
+        public async Task GetIngredientList_NonNumericPage_DefaultsToPage1Async()
+        {
+            // Arrange & Act
+            var response = await _client.GetAsync(ScopedListUrl + "&page=abc");
+            var html = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(BulkDataFixture.DefaultPageSize, CountTableBodyRows(html));
+        }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Fixtures/TestDbContext.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Fixtures/TestDbContext.cs
@@ -19,6 +19,7 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Fixtures
         public DbSet<MenuItem> MenuItems { get; set; }
         public DbSet<MenuItemIngredient> MenuItemIngredients { get; set; }
         public DbSet<Gift> Gifts { get; set; }
+        public DbSet<ValidatedProduct> ValidatedProducts { get; set; }
 
         public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
         {
@@ -33,6 +34,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Fixtures
 
             modelBuilder.Entity<Gift>()
                 .Property(g => g.Price).HasPrecision(10, 2);
+
+            modelBuilder.Entity<MenuItem>()
+                .Property(m => m.Price).HasPrecision(10, 2);
 
             modelBuilder.Entity<MenuItemIngredient>(entity =>
             {
@@ -156,5 +160,30 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Fixtures
         public TimeOnly AvailableFrom { get; set; }
         public string Description { get; set; } = "";
         public string Notes { get; set; } = "";
+    }
+
+    public class ValidatedProduct
+    {
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public int Id { get; set; }
+
+        [Required]
+        [MaxLength(50)]
+        public string Name { get; set; }
+
+        [Range(1, 1000)]
+        public int Quantity { get; set; }
+
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Must be 5 digits")]
+        public string PostalCode { get; set; }
+
+        [EmailAddress]
+        public string Email { get; set; }
+
+        [Url]
+        public string Website { get; set; }
+
+        [RegularExpression(@"(?i)^allowed$")]
+        public string CaseInsensitive { get; set; }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/MiddlewareTests/ApiDispatcherMutationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/MiddlewareTests/ApiDispatcherMutationTests.cs
@@ -298,9 +298,9 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.MiddlewareTests
             var decodedLocation = Uri.UnescapeDataString(location).Replace(" ", "+").ToLower();
             Assert.Contains("deleted+1+ingredient.", decodedLocation);
 
-            // Verify record is actually gone (fetching a deleted record throws)
-            await Assert.ThrowsAnyAsync<Exception>(
-                () => _client.GetAsync($"/admin/Ingredient/{id}/change/"));
+            // Verify record is actually gone (fetching a deleted record returns 404)
+            var fetchResponse = await _client.GetAsync($"/admin/Ingredient/{id}/change/");
+            Assert.Equal(HttpStatusCode.NotFound, fetchResponse.StatusCode);
         }
 
         [Fact]

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/MiddlewareTests/ApiDispatcherMutationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/MiddlewareTests/ApiDispatcherMutationTests.cs
@@ -125,6 +125,97 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.MiddlewareTests
             Assert.Equal(false, result);
         }
 
+        // ── ConvertValue culture-invariance (must match FieldValidator) ─
+
+        [Fact]
+        public void ConvertValue_DateTimeWithSlashSeparator_ParsesUnderInvariantCultureRegardlessOfThreadCulture()
+        {
+            // Arrange — under pt-BR thread culture, default TryParse reads "03/12/2025" as dd/MM (3-Dec).
+            // Binder must align with FieldValidator (InvariantCulture, MM/dd/yyyy), so the parsed value
+            // is March 12 regardless of the host thread culture.
+            var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("pt-BR");
+            try
+            {
+                // Act
+                var result = ApiDispatcher.ConvertValue("03/12/2025", DataType.DateTime);
+
+                // Assert
+                Assert.IsType<DateTime>(result);
+                Assert.Equal(new DateTime(2025, 3, 12), result);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+            }
+        }
+
+        [Fact]
+        public void ConvertValue_DateOnlyWithSlashSeparator_ParsesUnderInvariantCultureRegardlessOfThreadCulture()
+        {
+            // Arrange
+            var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("pt-BR");
+            try
+            {
+                // Act
+                var result = ApiDispatcher.ConvertValue("03/12/2025", DataType.Date, typeof(DateOnly));
+
+                // Assert
+                Assert.IsType<DateOnly>(result);
+                Assert.Equal(new DateOnly(2025, 3, 12), result);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+            }
+        }
+
+        [Fact]
+        public void ConvertValue_DateTimeOffsetWithSlashSeparator_ParsesUnderInvariantCultureRegardlessOfThreadCulture()
+        {
+            // Arrange
+            var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("pt-BR");
+            try
+            {
+                // Act
+                var result = ApiDispatcher.ConvertValue("03/12/2025", DataType.DateTime, typeof(DateTimeOffset));
+
+                // Assert
+                Assert.IsType<DateTimeOffset>(result);
+                var dto = (DateTimeOffset)result;
+                Assert.Equal(2025, dto.Year);
+                Assert.Equal(3, dto.Month);
+                Assert.Equal(12, dto.Day);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+            }
+        }
+
+        [Fact]
+        public void ConvertValue_TimeSpanWithColonSeparator_ParsesUnderInvariantCulture()
+        {
+            // Arrange — TimeSpan parsing also pinned to InvariantCulture for binder/validator parity.
+            var previous = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("pt-BR");
+            try
+            {
+                // Act
+                var result = ApiDispatcher.ConvertValue("14:30:00", DataType.Time);
+
+                // Assert
+                Assert.IsType<TimeSpan>(result);
+                Assert.Equal(new TimeSpan(14, 30, 0), result);
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = previous;
+            }
+        }
+
         // ── Create: missing _save_action defaults to "save" ─────────────
 
         [Fact]

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/MiddlewareTests/ApiDispatcherMutationTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/MiddlewareTests/ApiDispatcherMutationTests.cs
@@ -698,5 +698,137 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.MiddlewareTests
             var location = response.Headers.Location.ToString();
             Assert.Contains("_msg_level=error", location);
         }
+
+        // ── Action POST without form content type returns 400 ───────────
+
+        [Fact]
+        public async Task ActionPost_WithoutFormContentType_Returns400Async()
+        {
+            // Arrange — JSON body must be rejected: HandleActionAsync gates on HasFormContentType.
+            var jsonContent = new StringContent(
+                "{\"action\":\"delete_selected\"}",
+                System.Text.Encoding.UTF8,
+                "application/json");
+
+            // Act
+            var response = await _client.PostAsync("/admin/Category/action/", jsonContent);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        // ── Validation re-render uses the create form, not the edit form ─
+
+        [Fact]
+        public async Task CreatePost_ValidationError_RendersCreateFormNotEditFormAsync()
+        {
+            // Arrange — empty required Name fails validation and triggers re-render.
+            var formData = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", ""),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/Category/add/", formData);
+
+            // Assert — validation re-render returns 400 by design.
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var html = await response.Content.ReadAsStringAsync();
+            Assert.Contains("This field is required.", html);
+            // "Add" path renders the add breadcrumb; the Edit form would render "Change".
+            Assert.Contains("Add ", html);
+            Assert.DoesNotContain("Change ", html);
+        }
+
+        // ── Validation re-render on edit uses the edit form, not create ─
+
+        [Fact]
+        public async Task UpdatePost_ValidationError_RendersEditFormNotCreateFormAsync()
+        {
+            // Arrange — seed a record, then submit an edit with an empty required field.
+            var createForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", "MutTest_EditRender_" + Guid.NewGuid().ToString("N")[..6]),
+                new KeyValuePair<string, string>("_save_action", "continue"),
+            });
+            var createResponse = await _client.PostAsync("/admin/Ingredient/add/", createForm);
+            var id = ExtractIdFromRedirect(createResponse.Headers.Location.ToString(), "Ingredient");
+
+            var updateForm = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("Name", ""),
+            });
+
+            // Act
+            var response = await _client.PostAsync($"/admin/Ingredient/{id}/change/", updateForm);
+
+            // Assert — validation re-render returns 400 by design.
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            var html = await response.Content.ReadAsStringAsync();
+            Assert.Contains("This field is required.", html);
+            Assert.Contains("Change ", html);
+            Assert.DoesNotContain("Add ", html);
+        }
+
+        // ── Custom action with empty selection is blocked by descriptor guard ─
+
+        [Fact]
+        public async Task ActionPost_CustomActionEmptySelection_GuardsByDescriptorAsync()
+        {
+            // Arrange — test_action is registered without AllowEmptySelection = true, so the
+            // empty-selection guard must short-circuit before the handler runs. If the guard
+            // fires, we redirect to the list without a _msg= query param (handler not invoked).
+            var formData = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("action", "test_action"),
+            });
+
+            // Act
+            var response = await _client.PostAsync("/admin/Category/action/", formData);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+            var location = response.Headers.Location.ToString();
+            Assert.EndsWith("/admin/Category/", location);
+            Assert.DoesNotContain("_msg=", location);
+        }
+
+        // Mutants left uncovered by design (documented for future Stryker re-runs):
+        //
+        // - FetchDatasetAsync isLookup "true" → "false" (id=349): hard to kill without asserting
+        //   that the lookup JSON excludes non-lookup attributes. The provider decides the shape,
+        //   and the current seed doesn't give us a way to distinguish both projections reliably
+        //   at the HTTP level.
+        //
+        // - StripBlankPasswordFields "continue" removals on non-Password / empty-prop / missing-
+        //   key branches (id=355/359/361): a mutation that strips an empty nullable string from
+        //   props is not observable through the HTTP layer — the persisted value round-trips the
+        //   same as "" in form controls, so both produce the same re-render.
+        //
+        // - Token ternary "Type == JTokenType.String ? Value<string>() : ToString()" (id=362/363/
+        //   364): equivalent under the current POST pipeline. Every password-typed attribute that
+        //   reaches StripBlankPasswordFields is a JValue whose Value<string>() and ToString() are
+        //   byte-identical.
+        //
+        // - FormToJObject Lookup attr "DataAttr == null" → "!= null" (id=373 / id=374 NoCoverage):
+        //   the mutation either NREs on DataAttr.PropName (no DataAttr) or silently drops FK
+        //   values. The existing FK-persist test should kill it, but the assertion only inspects
+        //   the edit form, and the FK-missing case degrades to an integration error that isn't
+        //   exercised consistently enough to kill the boolean flip.
+        //
+        // - formValue.FirstOrDefault() → First() (id=378): equivalent. FormCollection never
+        //   returns an empty StringValues entry for a key that TryGetValue matched.
+        //
+        // - "p.Value.Type == JTokenType.Null ? null : ToObject<object>()" forced to else
+        //   (id=395): equivalent. ToObject<object>() on a JTokenType.Null value also returns null.
+        //
+        // - ActionDescriptors?.FirstOrDefault(a => a.Name == actionName) mutations (id=483/484/
+        //   485): equivalent under the test fixture. Every registered handler has a matching
+        //   descriptor with AllowEmptySelection=false, so FirstOrDefault vs First and == vs !=
+        //   resolve to the same descriptor instance. Requires fixture changes to differentiate.
+        //
+        // - Custom action catch-block error message mutations (id=497/498/499 NoCoverage): the
+        //   handler delegates registered in the fixture never throw; covering these would
+        //   require adding a throwing action, which is out of scope for this test file.
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
@@ -1,0 +1,989 @@
+using System;
+using System.Linq;
+
+using NDjango.Admin.AspNetCore.AdminDashboard.Services;
+
+using Newtonsoft.Json.Linq;
+
+using Xunit;
+
+namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Services
+{
+    public class FieldValidatorTests
+    {
+        private static MetaEntity CreateEntity(Action<MetaData, MetaEntity> configure)
+        {
+            var model = new MetaData();
+            var entity = model.AddEntity(null, "TestEntity");
+            configure(model, entity);
+            return entity;
+        }
+
+        private static MetaEntityAttr AddAttr(
+            MetaData model,
+            MetaEntity entity,
+            string propName,
+            DataType dataType = DataType.String,
+            bool isNullable = true,
+            EntityAttrKind kind = EntityAttrKind.Data,
+            bool isEditable = true)
+        {
+            var attr = model.AddEntityAttr(new MetaEntityAttrDescriptor
+            {
+                Parent = entity,
+                Expression = "TestEntity." + propName,
+                DataType = dataType,
+                Kind = kind
+            });
+            attr.PropName = propName;
+            attr.IsNullable = isNullable;
+            attr.IsEditable = isEditable;
+            return attr;
+        }
+
+        [Fact]
+        public void Validate_NullEntity_ReturnsEmptyErrors()
+        {
+            // Arrange
+            MetaEntity entity = null;
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_RequiredFieldMissing_ReturnsRequiredError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false));
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Name", errors[0].PropName);
+            Assert.Equal("This field is required.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_RequiredFieldEmptyString_ReturnsRequiredError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false));
+            var props = new JObject { ["Name"] = "" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("This field is required.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_RequiredFieldNullToken_ReturnsRequiredError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false));
+            var props = new JObject { ["Name"] = JValue.CreateNull() };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("This field is required.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NullableFieldMissing_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: true));
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_BoolFieldMissing_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "IsActive", DataType.Bool, isNullable: false));
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_NonEditableField_IsSkipped()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "CreatedAt", DataType.DateTime,
+                    isNullable: false, isEditable: false));
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_LookupKind_IsSkipped()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Category", DataType.String,
+                    isNullable: false, kind: EntityAttrKind.Lookup));
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_RequiredFieldHiddenOnCreate_IsSkipped()
+        {
+            // Arrange — non-nullable field hidden from the create form; creating shouldn't fail on required
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Payload", DataType.Blob, isNullable: false);
+                attr.ShowOnCreate = false;
+            });
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props, isEdit: false);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_RequiredFieldHiddenOnEdit_IsSkipped()
+        {
+            // Arrange — non-nullable field hidden from the edit form; editing shouldn't flag required
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Payload", DataType.Blob, isNullable: false);
+                attr.ShowOnEdit = false;
+            });
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props, isEdit: true);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_EmptyPropName_IsSkipped()
+        {
+            // Arrange
+            var model = new MetaData();
+            var entity = model.AddEntity(null, "TestEntity");
+            var attr = model.AddEntityAttr(new MetaEntityAttrDescriptor
+            {
+                Parent = entity,
+                Expression = "TestEntity.Name",
+                DataType = DataType.String
+            });
+            attr.PropName = null;
+            attr.IsNullable = false;
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_MaxLengthExceeded_ReturnsAtMostError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                attr.MaxLength = 5;
+            });
+            var props = new JObject { ["Name"] = "too long" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("at most 5 characters", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_MaxLengthAtBoundary_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                attr.MaxLength = 5;
+            });
+            var props = new JObject { ["Name"] = "hello" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_MinLengthBelow_ReturnsAtLeastError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                attr.MinLength = 5;
+            });
+            var props = new JObject { ["Name"] = "hi" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("at least 5 characters", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeBelow_ReturnsGreaterThanError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MinValue = 1;
+                attr.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "0" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("greater than or equal to 1", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeAbove_ReturnsLessThanError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MinValue = 1;
+                attr.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "999" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("less than or equal to 100", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeWithin_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MinValue = 1;
+                attr.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "42" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeWithNonNumericValue_ReturnsEnterValidNumber()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MinValue = 1;
+                attr.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "not a number" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid integer number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeOnNonNumericDataType_IsSkipped()
+        {
+            // Arrange — MinValue set but DataType is String so range rule doesn't apply
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                attr.MinValue = 1;
+            });
+            var props = new JObject { ["Name"] = "abc" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_DateTimeRangeBelow_ReturnsOnOrAfterError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false);
+                attr.MinDateTime = new DateTime(2020, 1, 1);
+                attr.MaxDateTime = new DateTime(2030, 12, 31);
+            });
+            var props = new JObject { ["Birthday"] = "2019-06-01" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("on or after 2020-01-01", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_DateTimeRangeAbove_ReturnsOnOrBeforeError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false);
+                attr.MinDateTime = new DateTime(2020, 1, 1);
+                attr.MaxDateTime = new DateTime(2030, 12, 31);
+            });
+            var props = new JObject { ["Birthday"] = "2031-06-01" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("on or before 2030-12-31", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_DateTimeRangeUnparseable_ReturnsEnterValidDate()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false);
+                attr.MinDateTime = new DateTime(2020, 1, 1);
+            });
+            var props = new JObject { ["Birthday"] = "nonsense" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid date.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_RegexMismatch_ReturnsCustomErrorMessage()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "PostalCode", DataType.String, isNullable: false);
+                attr.RegexPattern = @"^\d{5}$";
+                attr.RegexErrorMessage = "Must be 5 digits";
+            });
+            var props = new JObject { ["PostalCode"] = "abc" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Must be 5 digits", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_RegexMismatchWithoutCustomMessage_ReturnsGenericMessage()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Code", DataType.String, isNullable: false);
+                attr.RegexPattern = @"^\d+$";
+            });
+            var props = new JObject { ["Code"] = "abc" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid value.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_RegexWithInlineFlags_ServerEnforcesMatch()
+        {
+            // Arrange — inline flags are stripped from HTML5 output but still enforced server-side
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "CaseInsensitive", DataType.String, isNullable: false);
+                attr.RegexPattern = @"(?i)^allowed$";
+            });
+            var props = new JObject { ["CaseInsensitive"] = "disallowed" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+        }
+
+        [Fact]
+        public void Validate_RegexWithInlineFlagsMatches_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "CaseInsensitive", DataType.String, isNullable: false);
+                attr.RegexPattern = @"(?i)^allowed$";
+            });
+            var props = new JObject { ["CaseInsensitive"] = "ALLOWED" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_InvalidRegexPattern_ReturnsGenericError()
+        {
+            // Arrange — unmatched open group produces ArgumentException
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Bad", DataType.String, isNullable: false);
+                attr.RegexPattern = "([";
+            });
+            var props = new JObject { ["Bad"] = "hello" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid value.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_EmailInvalid_ReturnsEmailError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Email", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Email;
+            });
+            var props = new JObject { ["Email"] = "not-an-email" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid email address.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_EmailValid_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Email", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Email;
+            });
+            var props = new JObject { ["Email"] = "ok@example.com" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_UrlInvalid_ReturnsUrlError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Website", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Url;
+            });
+            var props = new JObject { ["Website"] = "not a url" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid URL.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_UrlValid_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Website", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Url;
+            });
+            var props = new JObject { ["Website"] = "https://example.com" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_TelInputType_AcceptsAnyFormat()
+        {
+            // Arrange — Tel enforces no pattern server-side (keyboard hint only)
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Phone", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Tel;
+            });
+            var props = new JObject { ["Phone"] = "garbage-value-still-ok" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_MaxLengthBeatsRegex_StopsAtFirstFailingRule()
+        {
+            // Arrange — value fails both MaxLength and RegexPattern; length runs first
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                attr.MaxLength = 3;
+                attr.RegexPattern = @"^\d+$";
+            });
+            var props = new JObject { ["Name"] = "abcdef" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("at most 3 characters", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_MultipleFieldsWithErrors_ReturnsAllErrors()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                var q = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                q.MinValue = 1;
+                q.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "9999" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Equal(2, errors.Count);
+            Assert.Contains(errors, e => e.PropName == "Name");
+            Assert.Contains(errors, e => e.PropName == "Quantity");
+        }
+
+        [Fact]
+        public void Validate_AllValidFields_ReturnsEmpty()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var name = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                name.MaxLength = 50;
+
+                var qty = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                qty.MinValue = 1;
+                qty.MaxValue = 1000;
+
+                var email = AddAttr(model, ent, "Email", DataType.String, isNullable: true);
+                email.InputType = InputTypeHint.Email;
+            });
+            var props = new JObject
+            {
+                ["Name"] = "Valid",
+                ["Quantity"] = "42",
+                ["Email"] = "ok@example.com"
+            };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeOnFloatType_EnforcesBounds()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Weight", DataType.Float, isNullable: false);
+                attr.MinValue = 0m;
+                attr.MaxValue = 99m;
+            });
+            var props = new JObject { ["Weight"] = "150.5" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("less than or equal to 99", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeOnCurrency_EnforcesBounds()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Price", DataType.Currency, isNullable: false);
+                attr.MinValue = 1m;
+            });
+            var props = new JObject { ["Price"] = "0.50" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("greater than or equal to 1", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_OnlyFirstErrorPerFieldReturned()
+        {
+            // Arrange — value violates both MinLength and MaxLength is impossible; use regex+email
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Email", DataType.String, isNullable: false);
+                attr.MinLength = 20;
+                attr.InputType = InputTypeHint.Email;
+            });
+            var props = new JObject { ["Email"] = "bad" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+        }
+
+        [Fact]
+        public void Validate_NonNumericDecimalWithoutRange_ReturnsEnterValidNumber()
+        {
+            // Arrange — Currency with no range should still reject non-numeric input
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Price", DataType.Currency, isNullable: false));
+            var props = new JObject { ["Price"] = "not-a-number" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NonNumericInt32WithoutRange_ReturnsEnterValidInteger()
+        {
+            // Arrange — Int32 with no range should reject non-numeric input
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Count", DataType.Int32, isNullable: false));
+            var props = new JObject { ["Count"] = "abc" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid integer number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_ByteOverflow_ReturnsByteRangeError()
+        {
+            // Arrange — Byte range is 0-255; 999 overflows
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "MinAge", DataType.Byte, isNullable: false));
+            var props = new JObject { ["MinAge"] = "999" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("between 0 and 255", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_InvalidGuid_ReturnsEnterValidUuid()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Uid", DataType.Guid, isNullable: false));
+            var props = new JObject { ["Uid"] = "not-a-guid" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid UUID value.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_ValidGuid_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Uid", DataType.Guid, isNullable: false));
+            var props = new JObject { ["Uid"] = "11111111-1111-1111-1111-111111111111" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_DecimalOverflowPrecisionScale_ReturnsDigitsBeforeDecimalError()
+        {
+            // Arrange — decimal(10,2) allows 8 integer digits; 999999999 has 9
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Price", DataType.Currency, isNullable: false);
+                attr.Precision = 10;
+                attr.Scale = 2;
+            });
+            var props = new JObject { ["Price"] = "999999999.99" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("no more than 8 digits before the decimal point", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_DecimalWithinPrecisionScale_ReturnsNoError()
+        {
+            // Arrange — decimal(10,2); 12345678.99 fits exactly
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Price", DataType.Currency, isNullable: false);
+                attr.Precision = 10;
+                attr.Scale = 2;
+            });
+            var props = new JObject { ["Price"] = "12345678.99" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_InvalidDateWithoutRange_ReturnsEnterValidDate()
+        {
+            // Arrange — DateTime with no range; parse still enforced
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false));
+            var props = new JObject { ["Birthday"] = "garbage" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid date.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_StringContainingNullByte_ReturnsNullCharacterError()
+        {
+            // Arrange — SQL Server rejects \0 in nvarchar via TDS; surface a user-friendly error instead of HTTP 500
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false));
+            var props = new JObject { ["Name"] = "hello\0world" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Name", errors[0].PropName);
+            Assert.Equal("Null characters are not allowed.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_MemoContainingNullByte_ReturnsNullCharacterError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Notes", DataType.Memo, isNullable: false));
+            var props = new JObject { ["Notes"] = "leading\0text" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Null characters are not allowed.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_FixedCharContainingNullByte_ReturnsNullCharacterError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Code", DataType.FixedChar, isNullable: false));
+            var props = new JObject { ["Code"] = "A\0B" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Null characters are not allowed.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NullByteOnNonStringType_ReturnsNoNullByteError()
+        {
+            // Arrange — non-string types already fail parse; null-byte check is string-only
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false));
+            var props = new JObject { ["Quantity"] = "1\02" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert — parse error, not null-byte error
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid integer number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NullByteBeatsMaxLength_StopsAtFirstFailingRule()
+        {
+            // Arrange — string has null byte AND exceeds MaxLength; null-byte check runs first
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Name", DataType.String, isNullable: false);
+                attr.MaxLength = 3;
+            });
+            var props = new JObject { ["Name"] = "abcdef\0" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Null characters are not allowed.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_StringWithoutNullByte_ReturnsNoError()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false));
+            var props = new JObject { ["Name"] = "perfectly ordinary text" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+    }
+}

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
@@ -985,5 +985,160 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Services
             // Assert
             Assert.Empty(errors);
         }
+
+        [Fact]
+        public void Validate_EditFormPasswordMissing_IsSkipped()
+        {
+            // Arrange — password left blank on edit means "keep the current hash"
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Password", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Password;
+            });
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props, isEdit: true);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_CreateFormPasswordMissing_ReturnsRequiredError()
+        {
+            // Arrange — the password skip must be edit-only
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Password", DataType.String, isNullable: false);
+                attr.InputType = InputTypeHint.Password;
+            });
+            var props = new JObject();
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props, isEdit: false);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("This field is required.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NullableStringEmpty_ReturnsNoError()
+        {
+            // Arrange — empty value on a nullable field is valid and should not trigger any rule
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Note", DataType.String, isNullable: true);
+                attr.MinLength = 5;
+            });
+            var props = new JObject { ["Note"] = "" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_Int64Unparseable_ReturnsEnterValidInteger()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "BigCount", DataType.Int64, isNullable: false));
+            var props = new JObject { ["BigCount"] = "not-a-number" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid integer number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_WordUnparseable_ReturnsEnterValidInteger()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "SmallNum", DataType.Word, isNullable: false));
+            var props = new JObject { ["SmallNum"] = "abc" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid integer number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_ByteNonNumeric_ReturnsByteRangeError()
+        {
+            // Arrange — distinct from the overflow case, which already has coverage
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Flag", DataType.Byte, isNullable: false));
+            var props = new JObject { ["Flag"] = "nope" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid integer number between 0 and 255.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_FloatUnparseable_ReturnsEnterValidNumber()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Ratio", DataType.Float, isNullable: false));
+            var props = new JObject { ["Ratio"] = "not-a-float" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid number.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_TimeUnparseable_ReturnsEnterValidTime()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "StartAt", DataType.Time, isNullable: false));
+            var props = new JObject { ["StartAt"] = "25:99" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid time.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_PrecisionWithScaleEqualPrecision_ReturnsNoError()
+        {
+            // Arrange — scale == precision leaves zero integer digits; rule disables itself rather than
+            // rejecting every value, since the config is an edge case more than an authoring error.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Fraction", DataType.Currency, isNullable: false);
+                attr.Precision = 4;
+                attr.Scale = 4;
+            });
+            var props = new JObject { ["Fraction"] = "0.1234" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Globalization;
 using System.Linq;
+using System.Threading;
 
 using NDjango.Admin.AspNetCore.AdminDashboard.Services;
 
@@ -1183,6 +1185,179 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Services
 
             // Assert
             Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_DateTimeOffsetTokenUnderNonUSCulture_ReturnsNoError()
+        {
+            // Arrange — Mirrors the POST pipeline: ApiDispatcher.ConvertValue parses a DateTimeOffset
+            // string into a typed DateTimeOffset, then JToken.FromObject wraps it as a JValue(Date).
+            // FieldValidator must not reject the already-parsed value under locales that format
+            // DateTimeOffset with culture-specific date separators (e.g. pt-BR "dd/MM/yyyy").
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "ShippedAt", DataType.DateTime, isNullable: false));
+            var dto = new DateTimeOffset(2028, 6, 15, 10, 30, 0, TimeSpan.FromMinutes(330));
+            var props = new JObject { ["ShippedAt"] = JToken.FromObject(dto) };
+
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("pt-BR");
+
+                // Act
+                var errors = FieldValidator.Validate(entity, props);
+
+                // Assert
+                Assert.Empty(errors);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void Validate_DateTimeOffsetTokenWithDateRangeUnderNonUSCulture_ReturnsNoError()
+        {
+            // Arrange — DateTimeOffset value wrapped as typed JToken must also pass ValidateDateRange
+            // (which re-parses the string representation) when the server culture is non-US.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "ShippedAt", DataType.DateTime, isNullable: false);
+                attr.MinDateTime = new DateTime(2020, 1, 1);
+                attr.MaxDateTime = new DateTime(2030, 12, 31);
+            });
+            var dto = new DateTimeOffset(2028, 6, 15, 10, 30, 0, TimeSpan.FromMinutes(330));
+            var props = new JObject { ["ShippedAt"] = JToken.FromObject(dto) };
+
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("pt-BR");
+
+                // Act
+                var errors = FieldValidator.Validate(entity, props);
+
+                // Assert
+                Assert.Empty(errors);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void Validate_RegexOnNumericDataType_IsSkipped()
+        {
+            // Arrange — a [RegularExpression] accidentally placed on an Int32 would otherwise run
+            // against the already-parsed value. Regex rule must be string-only.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.RegexPattern = @"^\d{5}$";
+            });
+            var props = new JObject { ["Quantity"] = "42" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_RegexOnGuidDataType_IsSkipped()
+        {
+            // Arrange — Guid.TryParse accepts both 32- and 36-char shapes; a regex pattern added
+            // to a Guid property must not gate those.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Uid", DataType.Guid, isNullable: false);
+                attr.RegexPattern = "^will-not-match$";
+            });
+            var props = new JObject { ["Uid"] = "11111111-1111-1111-1111-111111111111" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_RegexOnMemoDataType_StillEnforced()
+        {
+            // Arrange — Memo is text; regex should still apply.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Notes", DataType.Memo, isNullable: false);
+                attr.RegexPattern = @"^\d+$";
+            });
+            var props = new JObject { ["Notes"] = "letters" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid value.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_EmailInputTypeOnNonStringDataType_IsSkipped()
+        {
+            // Arrange — Email hint mistakenly applied to an Int32. The parsed value must not be
+            // re-evaluated as an email string.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Code", DataType.Int32, isNullable: false);
+                attr.InputType = InputTypeHint.Email;
+            });
+            var props = new JObject { ["Code"] = "42" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_UrlInputTypeOnDateDataType_IsSkipped()
+        {
+            // Arrange
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "WhenAt", DataType.DateTime, isNullable: false);
+                attr.InputType = InputTypeHint.Url;
+            });
+            var props = new JObject { ["WhenAt"] = "2025-05-01" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_EmailInputTypeOnFixedCharDataType_StillEnforced()
+        {
+            // Arrange — FixedChar is a text type; Email hint should still be enforced.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Contact", DataType.FixedChar, isNullable: false);
+                attr.InputType = InputTypeHint.Email;
+            });
+            var props = new JObject { ["Contact"] = "not-an-email" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Enter a valid email address.", errors[0].Message);
         }
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
@@ -1359,5 +1359,221 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Services
             Assert.Single(errors);
             Assert.Equal("Enter a valid email address.", errors[0].Message);
         }
+
+        [Fact]
+        public void Validate_PrecisionOnFloatType_EnforcesDigits()
+        {
+            // Arrange — the "!= Currency && != Float" guard in ValidatePrecision must include Float.
+            // Removing the Float branch would let oversized Float values pass silently.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Ratio", DataType.Float, isNullable: false);
+                attr.Precision = 5;
+                attr.Scale = 2;
+            });
+            var props = new JObject { ["Ratio"] = "1234567.89" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("no more than 3 digits before the decimal point", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NullByteAtStartOfValue_ReturnsNullCharacterError()
+        {
+            // Arrange — null byte at index 0 must still be rejected. Check is "IndexOf >= 0", not "> 0".
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Name", DataType.String, isNullable: false));
+            var props = new JObject { ["Name"] = "\0leading" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Equal("Null characters are not allowed.", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_MinLengthAtBoundary_ReturnsNoError()
+        {
+            // Arrange — value length exactly equal to MinLength satisfies the rule (strict <).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Code", DataType.String, isNullable: false);
+                attr.MinLength = 5;
+            });
+            var props = new JObject { ["Code"] = "12345" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_RangeWithOnlyMaxValueAboveLimit_ReturnsLessThanError()
+        {
+            // Arrange — MaxValue alone (no MinValue) must still trigger range enforcement. The
+            // early-return requires BOTH bounds absent (AND, not OR).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MaxValue = 10;
+            });
+            var props = new JObject { ["Quantity"] = "20" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("less than or equal to 10", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeAtMinValueBoundary_ReturnsNoError()
+        {
+            // Arrange — value equal to MinValue passes (strict <, not <=).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MinValue = 5;
+                attr.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "5" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_NumericRangeAtMaxValueBoundary_ReturnsNoError()
+        {
+            // Arrange — value equal to MaxValue passes (strict >, not >=).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Quantity", DataType.Int32, isNullable: false);
+                attr.MinValue = 1;
+                attr.MaxValue = 100;
+            });
+            var props = new JObject { ["Quantity"] = "100" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_DateRangeWithOnlyMinDateTime_ReturnsOnOrAfterError()
+        {
+            // Arrange — MinDateTime alone must still be enforced. The early-return requires BOTH
+            // Min and Max absent (AND, not OR).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false);
+                attr.MinDateTime = new DateTime(2020, 1, 1);
+            });
+            var props = new JObject { ["Birthday"] = "2019-06-01" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("on or after 2020-01-01", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_DateTimeRangeAtMinBoundary_ReturnsNoError()
+        {
+            // Arrange — value equal to MinDateTime passes (strict <, not <=).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false);
+                attr.MinDateTime = new DateTime(2020, 1, 1);
+            });
+            var props = new JObject { ["Birthday"] = "2020-01-01" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_DateTimeRangeAtMaxBoundary_ReturnsNoError()
+        {
+            // Arrange — value equal to MaxDateTime passes (strict >, not >=).
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "Birthday", DataType.DateTime, isNullable: false);
+                attr.MaxDateTime = new DateTime(2030, 12, 31);
+            });
+            var props = new JObject { ["Birthday"] = "2030-12-31" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        [Fact]
+        public void Validate_StringFieldWithBooleanToken_TreatsAsNonEmpty()
+        {
+            // Arrange — FormatTokenInvariant's "?? string.Empty" fallback must use the token's
+            // ToString result, not collapse to "". The only reachable non-IFormattable JValue
+            // payload is a bool. If the fallback dropped the value, the empty stringValue would
+            // trip "This field is required." on a non-nullable non-Bool attribute.
+            var entity = CreateEntity((model, ent) =>
+                AddAttr(model, ent, "Flag", DataType.String, isNullable: false));
+            var props = new JObject { ["Flag"] = new JValue(true) };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
+
+        // Mutants left uncovered by design (documented for future Stryker re-runs):
+        //
+        // - Validate hasValue "&& token != null" → "|| token != null" (id=2341):
+        //   equivalent. For a JValue(null) token the mutation flips hasValue to true, but the
+        //   resulting empty stringValue still triggers the same "required" error (or is skipped
+        //   for nullable/bool attributes), so the outcome is identical.
+        //
+        // - Ternary in stringValue "Type == String ? token.Value<string>() : FormatTokenInvariant"
+        //   forced to else branch (id=2361): equivalent. Both branches produce the same string for
+        //   string-typed JValue tokens (FormatTokenInvariant falls through to jv.Value.ToString()).
+        //
+        // - "continue;" on the required-empty branch removed (id=2373): equivalent. The next
+        //   "if (string.IsNullOrEmpty(stringValue)) continue;" on the following line produces the
+        //   same outcome after the FieldError has already been added.
+        //
+        // - "Precision.Value <= 0" → "< 0" (id=2426) and "integerPart == 0 ? 1 : .Length" forced
+        //   to else (id=2434) and ToString format "F0" → "" (id=2436): equivalent. maxIntegerDigits
+        //   becomes 0 when Precision == 0 and the next guard returns null regardless. The ternary
+        //   and format-string changes produce the exact same digit count for a Truncated decimal.
+        //
+        // NoCoverage survivors flagged as unreachable under the documented invariants:
+        // - FormatTokenInvariant fallback "Stryker was here" (id=2386): unreachable. Null-typed
+        //   JTokens are filtered out earlier via hasValue.
+        // - ValidateRange "Enter a valid number." (id=2475) and ValidateDateRange "Enter a valid
+        //   date." (id=2495): unreachable via the ValidateAttribute pipeline. ValidateParse runs
+        //   first with the same parser/culture, so any value reaching here already parsed once.
+        // - ValidateRegex RegexMatchTimeoutException "Enter a valid value." (id=2523): requires a
+        //   ReDoS-crafted pattern exceeding 250ms. Skipped to keep the test suite deterministic.
     }
 }

--- a/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
+++ b/test/NDjango.Admin.AspNetCore.AdminDashboard.Tests/Services/FieldValidatorTests.cs
@@ -1140,5 +1140,49 @@ namespace NDjango.Admin.AspNetCore.AdminDashboard.Tests.Services
             // Assert
             Assert.Empty(errors);
         }
+
+        [Fact]
+        public void Validate_PrecisionLargeDecimalOverflow_ReturnsDigitsBeforeDecimalError()
+        {
+            // Arrange — Precision=20, Scale=2 => 18 integer digits allowed. 19-digit integer part
+            // exceeds double's ~15-17 significant-digit range, so a Math.Log10((double)integerPart)
+            // calculation can floor to 18 and under-count the digits. Counting on the decimal directly
+            // must still reject the value.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "BigPrice", DataType.Currency, isNullable: false);
+                attr.Precision = 20;
+                attr.Scale = 2;
+            });
+            var props = new JObject { ["BigPrice"] = "1234567890123456789.99" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Single(errors);
+            Assert.Contains("no more than 18 digits before the decimal point", errors[0].Message);
+        }
+
+        [Fact]
+        public void Validate_PrecisionPowerOfTenAtBoundary_AcceptsExactDigitCount()
+        {
+            // Arrange — 10^7 has exactly 8 integer digits; Precision=10, Scale=2 allows 8. Math.Log10(1e7)
+            // can return 6.99999... due to FP rounding, which would incorrectly pass "7 digits" when the
+            // value actually has 8. String-length digit counting avoids the trap.
+            var entity = CreateEntity((model, ent) =>
+            {
+                var attr = AddAttr(model, ent, "EdgePrice", DataType.Currency, isNullable: false);
+                attr.Precision = 10;
+                attr.Scale = 2;
+            });
+            var props = new JObject { ["EdgePrice"] = "10000000.00" };
+
+            // Act
+            var errors = FieldValidator.Validate(entity, props);
+
+            // Assert
+            Assert.Empty(errors);
+        }
     }
 }

--- a/test/NDjango.Admin.EntityFrameworkCore.Relational.Tests/DbContextMetaDataLoaderValidationTests.cs
+++ b/test/NDjango.Admin.EntityFrameworkCore.Relational.Tests/DbContextMetaDataLoaderValidationTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Linq;
+
+using Xunit;
+
+namespace NDjango.Admin.EntityFrameworkCore.Relational.Tests
+{
+    public class DbContextMetaDataLoaderValidationTests
+    {
+        private readonly MetaData _metaData;
+
+        public DbContextMetaDataLoaderValidationTests()
+        {
+            // Arrange
+            var dbContext = DbContextWithValidation.Create();
+            _metaData = new MetaData();
+            _metaData.LoadFromDbContext(dbContext);
+        }
+
+        private MetaEntityAttr FindAttr(string propName)
+        {
+            var entity = _metaData.EntityRoot.SubEntities.Single();
+            return entity.Attributes.FirstOrDefault(a => a.PropName == propName);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_MaxLengthAttribute_PopulatesMaxLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.MaxLengthString));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(50, attr.MaxLength);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_FluentHasMaxLength_PopulatesMaxLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.FluentMaxLen));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(25, attr.MaxLength);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_StringLengthAttribute_PopulatesBothBounds()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.StringLengthField));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(100, attr.MaxLength);
+            Assert.Equal(3, attr.MinLength);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_MinLengthAttribute_PopulatesMinLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.MinLengthField));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(5, attr.MinLength);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_MinLengthZero_DoesNotPopulateMinLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.ZeroMinLengthField));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Null(attr.MinLength);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_IntRangeAttribute_PopulatesMinMaxValue()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.IntRange));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(1m, attr.MinValue);
+            Assert.Equal(1000m, attr.MaxValue);
+            Assert.Null(attr.MinDateTime);
+            Assert.Null(attr.MaxDateTime);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_DateTimeRange_PopulatesMinMaxDateTime()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.DateRange));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(new DateTime(2020, 1, 1), attr.MinDateTime);
+            Assert.Equal(new DateTime(2030, 12, 31), attr.MaxDateTime);
+            Assert.Null(attr.MinValue);
+            Assert.Null(attr.MaxValue);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_RegularExpression_PopulatesPatternAndErrorMessage()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.PostalCode));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(@"^\d{5}$", attr.RegexPattern);
+            Assert.Equal("Must be 5 digits", attr.RegexErrorMessage);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_RegularExpressionWithInlineFlags_StillStoresPattern()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.CaseInsensitivePattern));
+
+            // Assert
+            // Pattern is stored for server-side enforcement; renderer will decide
+            // whether to emit it via IsHtml5SafeRegex guard.
+            Assert.NotNull(attr);
+            Assert.Equal("(?i)^hello$", attr.RegexPattern);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_EmailAddress_SetsEmailInputType()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.Email));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(InputTypeHint.Email, attr.InputType);
+            Assert.Null(attr.RegexPattern);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_Url_SetsUrlInputType()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.Website));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(InputTypeHint.Url, attr.InputType);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_Phone_SetsTelInputTypeWithoutRegex()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.Phone));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(InputTypeHint.Tel, attr.InputType);
+            Assert.Null(attr.RegexPattern);
+        }
+
+        [Fact]
+        public void LoadFromDbContext_HasPrecision_PopulatesPrecisionAndScale()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationEntity.Price));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(10, attr.Precision);
+            Assert.Equal(2, attr.Scale);
+        }
+    }
+}

--- a/test/NDjango.Admin.EntityFrameworkCore.Relational.Tests/NDjangoAdminManagerEFTranslationTests.cs
+++ b/test/NDjango.Admin.EntityFrameworkCore.Relational.Tests/NDjangoAdminManagerEFTranslationTests.cs
@@ -1,0 +1,349 @@
+using System;
+
+using Microsoft.EntityFrameworkCore;
+
+using NDjango.Admin.Services;
+
+using Xunit;
+
+namespace NDjango.Admin.EntityFrameworkCore.Relational.Tests
+{
+    public class NDjangoAdminManagerEFTranslationTests
+    {
+        // ── SQL Server (Microsoft.Data.SqlClient.SqlException) ──
+
+        [Fact]
+        public void TranslateByProviderCode_MicrosoftSqlClientFk_ReturnsReferencedRecordError()
+        {
+            // Arrange
+            var inner = new Microsoft.Data.SqlClient.SqlException { Number = 547 };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("Referenced record does not exist.", result);
+        }
+
+        [Theory]
+        [InlineData(2601)]
+        [InlineData(2627)]
+        public void TranslateByProviderCode_MicrosoftSqlClientUnique_ReturnsDuplicateError(int number)
+        {
+            // Arrange
+            var inner = new Microsoft.Data.SqlClient.SqlException { Number = number };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("A record with the same unique value already exists.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_MicrosoftSqlClientNotNull_ReturnsRequiredFieldError()
+        {
+            // Arrange
+            var inner = new Microsoft.Data.SqlClient.SqlException { Number = 515 };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("A required field is missing.", result);
+        }
+
+        [Theory]
+        [InlineData(8152)]
+        [InlineData(2628)]
+        public void TranslateByProviderCode_MicrosoftSqlClientStringTruncation_ReturnsLengthError(int number)
+        {
+            // Arrange
+            var inner = new Microsoft.Data.SqlClient.SqlException { Number = number };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("One or more string values exceed the allowed length.", result);
+        }
+
+        [Theory]
+        [InlineData(220)]
+        [InlineData(232)]
+        [InlineData(8115)]
+        public void TranslateByProviderCode_MicrosoftSqlClientNumericOverflow_ReturnsRangeError(int number)
+        {
+            // Arrange
+            var inner = new Microsoft.Data.SqlClient.SqlException { Number = number };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("One or more numeric values are out of range.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_MicrosoftSqlClientUnknownNumber_ReturnsNull()
+        {
+            // Arrange
+            var inner = new Microsoft.Data.SqlClient.SqlException { Number = 9999 };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        // ── SQL Server (legacy System.Data.SqlClient.SqlException) ──
+
+        [Fact]
+        public void TranslateByProviderCode_LegacySystemSqlClient_StillRecognized()
+        {
+            // Arrange — the older System.Data.SqlClient.SqlException shape must still be mapped
+            var inner = new System.Data.SqlClient.SqlException { Number = 547 };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("Referenced record does not exist.", result);
+        }
+
+        // ── Postgres (Npgsql.PostgresException) ──
+
+        [Fact]
+        public void TranslateByProviderCode_NpgsqlForeignKey_ReturnsReferencedRecordError()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "23503" };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("Referenced record does not exist.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_NpgsqlUnique_ReturnsDuplicateError()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "23505" };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("A record with the same unique value already exists.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_NpgsqlNotNull_ReturnsRequiredFieldError()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "23502" };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("A required field is missing.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_NpgsqlStringTruncation_ReturnsLengthError()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "22001" };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("One or more string values exceed the allowed length.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_NpgsqlNumericOverflow_ReturnsRangeError()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "22003" };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("One or more numeric values are out of range.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_NpgsqlUnknownSqlState_ReturnsNull()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "99999" };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        // ── SQLite (Microsoft.Data.Sqlite.SqliteException) ──
+        // Uses the real SqliteException from Microsoft.Data.Sqlite (brought in transitively via
+        // the Sqlite EF Core package) so the public (message, errorCode, extendedErrorCode) ctor
+        // exercises the actual property shape the allow-list reflects against.
+
+        [Fact]
+        public void TranslateByProviderCode_SqliteExtendedForeignKey_ReturnsReferencedRecordError()
+        {
+            // Arrange — SQLITE_CONSTRAINT (19) / extended SQLITE_CONSTRAINT_FOREIGNKEY (787)
+            var inner = new Microsoft.Data.Sqlite.SqliteException("fk violated", 19, 787);
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("Referenced record does not exist.", result);
+        }
+
+        [Theory]
+        [InlineData(1555)]
+        [InlineData(2067)]
+        public void TranslateByProviderCode_SqliteExtendedUnique_ReturnsDuplicateError(int extendedCode)
+        {
+            // Arrange
+            var inner = new Microsoft.Data.Sqlite.SqliteException("unique violated", 19, extendedCode);
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("A record with the same unique value already exists.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_SqliteExtendedNotNull_ReturnsRequiredFieldError()
+        {
+            // Arrange — SQLITE_CONSTRAINT_NOTNULL
+            var inner = new Microsoft.Data.Sqlite.SqliteException("not null violated", 19, 1299);
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Equal("A required field is missing.", result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_SqliteUnknownExtendedCode_ReturnsNull()
+        {
+            // Arrange
+            var inner = new Microsoft.Data.Sqlite.SqliteException("other violation", 19, 9999);
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        // ── Unknown/unmapped providers ──
+
+        [Fact]
+        public void TranslateByProviderCode_UnknownProviderType_ReturnsNull()
+        {
+            // Arrange — third-party exception with a Number property that happens to match SQL Server's 547;
+            // allow-list must not pick it up because the full type name doesn't match.
+            var inner = new SomeOtherProvider.SqlException { Number = 547 };
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void TranslateByProviderCode_NullInner_ReturnsNull()
+        {
+            // Arrange
+            Exception inner = null;
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateByProviderCode(inner);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        // ── TranslateDbUpdateException wrapper: falls back to generic message when inner is unrecognized ──
+
+        [Fact]
+        public void TranslateDbUpdateException_UnknownInner_ReturnsGenericMessage()
+        {
+            // Arrange
+            var ex = new DbUpdateException("update failed", new InvalidOperationException("nope"));
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateDbUpdateException(ex);
+
+            // Assert
+            Assert.Equal("Unable to save the record due to a data constraint violation.", result);
+        }
+
+        [Fact]
+        public void TranslateDbUpdateException_RecognizedInner_ReturnsMappedMessage()
+        {
+            // Arrange
+            var inner = new Npgsql.PostgresException { SqlState = "23505" };
+            var ex = new DbUpdateException("unique violation", inner);
+
+            // Act
+            var result = NDjangoAdminManagerEF<DbContextWithValidation>.TranslateDbUpdateException(ex);
+
+            // Assert
+            Assert.Equal("A record with the same unique value already exists.", result);
+        }
+    }
+}
+
+// Stand-in exception types with the exact full type names checked by TranslateByProviderCode.
+// Needed because neither Microsoft.Data.SqlClient.SqlException nor Npgsql.PostgresException exposes
+// a public constructor that sets Number/SqlState — they can only be produced by an actual DB call.
+// Using fakes lets us exercise the allow-list deterministically without a real database round-trip.
+// (Microsoft.Data.Sqlite.SqliteException does have a public ctor and is used directly above.)
+namespace Microsoft.Data.SqlClient
+{
+    public class SqlException : Exception
+    {
+        public int Number { get; set; }
+    }
+}
+
+namespace System.Data.SqlClient
+{
+    public class SqlException : Exception
+    {
+        public int Number { get; set; }
+    }
+}
+
+namespace Npgsql
+{
+    public class PostgresException : Exception
+    {
+        public string SqlState { get; set; }
+    }
+}
+
+namespace SomeOtherProvider
+{
+    public class SqlException : Exception
+    {
+        public int Number { get; set; }
+    }
+}

--- a/test/NDjango.Admin.EntityFrameworkCore.Relational.Tests/TestData/DbContextWithValidation.cs
+++ b/test/NDjango.Admin.EntityFrameworkCore.Relational.Tests/TestData/DbContextWithValidation.cs
@@ -1,0 +1,74 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace NDjango.Admin.EntityFrameworkCore.Relational.Tests
+{
+    public class DbContextWithValidation : DbContext
+    {
+        public DbContextWithValidation(DbContextOptions options)
+            : base(options)
+        { }
+
+        public DbSet<ValidationEntity> ValidationEntities { get; set; }
+
+        public static DbContextWithValidation Create()
+        {
+            return new DbContextWithValidation(new DbContextOptionsBuilder()
+                .UseSqlite("Data Source = :memory:")
+                .Options);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ValidationEntity>(b =>
+            {
+                b.Property(e => e.FluentMaxLen).HasMaxLength(25);
+                b.Property(e => e.Price).HasPrecision(10, 2);
+            });
+        }
+    }
+
+    public class ValidationEntity
+    {
+        public int Id { get; set; }
+
+        [MaxLength(50)]
+        public string MaxLengthString { get; set; }
+
+        public string FluentMaxLen { get; set; }
+
+        [StringLength(maximumLength: 100, MinimumLength = 3)]
+        public string StringLengthField { get; set; }
+
+        [MinLength(5)]
+        public string MinLengthField { get; set; }
+
+        [MinLength(0)]
+        public string ZeroMinLengthField { get; set; }
+
+        [Range(1, 1000)]
+        public int IntRange { get; set; }
+
+        [Range(typeof(DateTime), "2020-01-01", "2030-12-31")]
+        public DateTime DateRange { get; set; }
+
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Must be 5 digits")]
+        public string PostalCode { get; set; }
+
+        [RegularExpression(@"(?i)^hello$")]
+        public string CaseInsensitivePattern { get; set; }
+
+        [EmailAddress]
+        public string Email { get; set; }
+
+        [Url]
+        public string Website { get; set; }
+
+        [Phone]
+        public string Phone { get; set; }
+
+        public decimal Price { get; set; }
+    }
+}

--- a/test/NDjango.Admin.MongoDB.Tests/IntegrationTests/MongoDetailViewTests.cs
+++ b/test/NDjango.Admin.MongoDB.Tests/IntegrationTests/MongoDetailViewTests.cs
@@ -66,16 +66,16 @@ namespace NDjango.Admin.MongoDB.Tests.IntegrationTests
         }
 
         [Fact]
-        public async Task InvalidId_ThrowsRecordNotFoundExceptionAsync()
+        public async Task InvalidId_Returns404Async()
         {
             // Arrange
             var invalidId = ObjectId.GenerateNewId().ToString();
 
-            // Act & Assert
-            var ex = await Assert.ThrowsAsync<RecordNotFoundException>(
-                () => _client.GetAsync($"/admin/TestCategory/{invalidId}/change/"));
+            // Act
+            var response = await _client.GetAsync($"/admin/TestCategory/{invalidId}/change/");
 
-            Assert.Contains(invalidId, ex.Message);
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
     }
 }

--- a/test/NDjango.Admin.MongoDB.Tests/MongoMetaDataLoaderTests.cs
+++ b/test/NDjango.Admin.MongoDB.Tests/MongoMetaDataLoaderTests.cs
@@ -175,6 +175,44 @@ namespace NDjango.Admin.MongoDB.Tests
         public DateTime CreatedDate { get; set; }
     }
 
+    public class ValidationDocument
+    {
+        public ObjectId Id { get; set; }
+
+        [MaxLength(50)]
+        public string MaxLengthString { get; set; }
+
+        [StringLength(maximumLength: 100, MinimumLength = 3)]
+        public string StringLengthField { get; set; }
+
+        [MinLength(5)]
+        public string MinLengthField { get; set; }
+
+        [MinLength(0)]
+        public string ZeroMinLengthField { get; set; }
+
+        [Range(1, 1000)]
+        public int IntRange { get; set; }
+
+        [Range(typeof(DateTime), "2020-01-01", "2030-12-31")]
+        public DateTime DateRange { get; set; }
+
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Must be 5 digits")]
+        public string PostalCode { get; set; }
+
+        [RegularExpression(@"(?i)^hello$")]
+        public string CaseInsensitivePattern { get; set; }
+
+        [EmailAddress]
+        public string Email { get; set; }
+
+        [Url]
+        public string Website { get; set; }
+
+        [Phone]
+        public string Phone { get; set; }
+    }
+
     #endregion
 
     public class MongoMetaDataLoaderTests
@@ -987,6 +1025,196 @@ namespace NDjango.Admin.MongoDB.Tests
             Assert.False(createdDateAttr.IsEditable);
             Assert.False(createdDateAttr.ShowOnCreate);
             Assert.True(createdDateAttr.ShowOnEdit);
+        }
+    }
+
+    public class MongoValidationMetadataTests
+    {
+        private readonly MetaEntity _entity;
+
+        public MongoValidationMetadataTests()
+        {
+            // Arrange
+            var model = new MetaData();
+            var collections = new List<MongoCollectionDescriptor>
+            {
+                new MongoCollectionDescriptor(typeof(ValidationDocument), "validation_docs")
+            };
+            var options = new MongoMetaDataLoaderOptions();
+
+            var loader = new MongoMetaDataLoader(model, collections, options);
+            loader.LoadFromCollections();
+
+            _entity = model.EntityRoot.SubEntities.Single();
+        }
+
+        private MetaEntityAttr FindAttr(string propName)
+        {
+            return _entity.Attributes.FirstOrDefault(a => a.PropName == propName);
+        }
+
+        [Fact]
+        public void LoadFromCollections_MaxLengthAttribute_PopulatesMaxLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.MaxLengthString));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(50, attr.MaxLength);
+        }
+
+        [Fact]
+        public void LoadFromCollections_StringLengthAttribute_PopulatesBothBounds()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.StringLengthField));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(100, attr.MaxLength);
+            Assert.Equal(3, attr.MinLength);
+        }
+
+        [Fact]
+        public void LoadFromCollections_MinLengthAttribute_PopulatesMinLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.MinLengthField));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(5, attr.MinLength);
+        }
+
+        [Fact]
+        public void LoadFromCollections_MinLengthZero_DoesNotPopulateMinLength()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.ZeroMinLengthField));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Null(attr.MinLength);
+        }
+
+        [Fact]
+        public void LoadFromCollections_IntRangeAttribute_PopulatesMinMaxValue()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.IntRange));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(1m, attr.MinValue);
+            Assert.Equal(1000m, attr.MaxValue);
+            Assert.Null(attr.MinDateTime);
+            Assert.Null(attr.MaxDateTime);
+        }
+
+        [Fact]
+        public void LoadFromCollections_DateTimeRange_PopulatesMinMaxDateTime()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.DateRange));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(new DateTime(2020, 1, 1), attr.MinDateTime);
+            Assert.Equal(new DateTime(2030, 12, 31), attr.MaxDateTime);
+            Assert.Null(attr.MinValue);
+            Assert.Null(attr.MaxValue);
+        }
+
+        [Fact]
+        public void LoadFromCollections_RegularExpression_PopulatesPatternAndErrorMessage()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.PostalCode));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(@"^\d{5}$", attr.RegexPattern);
+            Assert.Equal("Must be 5 digits", attr.RegexErrorMessage);
+        }
+
+        [Fact]
+        public void LoadFromCollections_RegularExpressionWithInlineFlags_StillStoresPattern()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.CaseInsensitivePattern));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal("(?i)^hello$", attr.RegexPattern);
+        }
+
+        [Fact]
+        public void LoadFromCollections_EmailAddress_SetsEmailInputType()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.Email));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(InputTypeHint.Email, attr.InputType);
+            Assert.Null(attr.RegexPattern);
+        }
+
+        [Fact]
+        public void LoadFromCollections_Url_SetsUrlInputType()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.Website));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(InputTypeHint.Url, attr.InputType);
+        }
+
+        [Fact]
+        public void LoadFromCollections_Phone_SetsTelInputTypeWithoutRegex()
+        {
+            // Arrange
+            // Metadata is loaded once in the constructor.
+
+            // Act
+            var attr = FindAttr(nameof(ValidationDocument.Phone));
+
+            // Assert
+            Assert.NotNull(attr);
+            Assert.Equal(InputTypeHint.Tel, attr.InputType);
+            Assert.Null(attr.RegexPattern);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `FieldValidator` service that enforces DataAnnotations (`MaxLength`, `StringLength`, `MinLength`, `Range`, `RegularExpression`, `EmailAddress`, `Url`, `Phone`, `DataType(Password)`) and EF Core metadata (`GetMaxLength`, `GetPrecision`, `GetScale`) on create/edit form POSTs, rebinding the form with errors on failure (Django-style bound-form behavior).
- Emits HTML5 input hints (`maxlength`, `minlength`, `min`, `max`, `pattern`, `title`, `step`, typed `email`/`url`/`tel`/`password` inputs) so the browser catches obvious issues before the round-trip.
- Translates `DbUpdateException` into a user-friendly `DataIntegrityException` using **locale-independent provider error codes only** (SQL Server `Number`, Postgres `SqlState`, SQLite `SqliteExtendedErrorCode`) — the earlier English-substring fallback was dropped because it silently degraded on non-English database servers.
- Applies a 250 ms `Regex` timeout on `RegularExpression` validation to guard against ReDoS.
- Preserves whitespace-only password submissions on create/edit (treats whitespace as a deliberate value rather than silently stripping it).

## Test plan
- [x] `FieldValidatorTests` — unit tests for each annotation and EF metadata source
- [x] `ValidationTests` — end-to-end form POST → rebind-with-errors flow
- [x] `AuthUserUpdateTests` — password edit behavior (whitespace preserved, empty strips)
- [x] `DbContextMetaDataLoaderValidationTests` — EF metadata → validation rule mapping
- [x] Full test suite: 1567/1567 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)