### PR TITLE
chore(deps): pin transitive picomatch to >=2.3.2 (CVE-2026-33672)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1357,6 +1358,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3646,9 +3648,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0"
   },
+  "overrides": {
+    "picomatch": "^2.3.2"
+  },
   "scripts": {
     "test": "jest --coverage"
   },


### PR DESCRIPTION
## Summary
- Adds an npm `overrides` entry pinning `picomatch` to `^2.3.2`, bumping the installed version from `2.3.1` -> `2.3.2`.
- Resolves Dependabot alert [#3](https://github.com/juntossomosmais/NDjango.Admin/security/dependabot/3) / GHSA-3v7f-55p6-f55p / CVE-2026-33672.

## Why this approach
`picomatch` is a transitive dev dependency pulled in several levels deep by Jest (`anymatch`, `micromatch`, `readdirp`). All consumers accept `^2.x`, so `^2.3.2` fits inside their existing semver ranges -- no parent upgrade needed, no breakage. The advisory provides patched versions on three lines (2.3.2, 3.0.2, 4.0.4); staying on the patched 2.x line is the minimal, semver-safe fix. Upgrading Jest would be disproportionate work for a dev-only transitive advisory.

## Vulnerability
Medium severity (CVSS 5.3, CWE-1321). POSIX character class handling (e.g. `[[:constructor:]]`) inherits `Object.prototype` method names, stringifies them into the generated regex, and causes incorrect glob matching. Not RCE, but an integrity bug wherever globs gate filtering/validation/access control.

## Test plan
- [x] `npm install` completes with no peer/dep conflicts
- [x] `npm test` -> 24/24 Jest tests pass
- [x] `package-lock.json` resolves `node_modules/picomatch` to `2.3.2`
- [ ] Dependabot alert #3 auto-closes after merge to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)